### PR TITLE
feat: enable pkgdown dev/release docs split

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FSSgam
 Title: Full Subsets Multiple Regression in R Using GAMs
-Version: 1.0.0
+Version: 1.0.0.9000
 Authors@R:
     person("Rebecca", "Fisher",
            email = "r.fisher@aims.gov.au",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# FSSgam (development version)
+
 # FSSgam 1.0.0
 
 Modernisation release ahead of CRAN submission.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,6 +3,9 @@ url: https://beckyfisher.github.io/FSSgam_package/
 template:
   bootstrap: 5
 
+development:
+  mode: auto
+
 repo:
   url:
     home: https://github.com/beckyfisher/FSSgam_package/


### PR DESCRIPTION
development: mode: auto in _pkgdown.yml makes pkgdown publish to docs/ when DESCRIPTION's Version is a release form (now true on master, 1.0.0) and to docs/dev/ when it's a devel form (now true here, bumped to 1.0.0.9000 via usethis::use_dev_version()). Both branches deploy to the same gh-pages branch non-destructively (deploy step already uses clean: false), so release and dev docs coexist once GitHub Pages is pointed at gh-pages.