### PR TITLE
Batch 2: raise the declared R floor to 4.4.0, and check it

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^pkgdown$
 ^prompts$
 ^planning$
+^tools$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,6 +23,19 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
+          # Establishes that the package builds, installs and passes its
+          # tests on an R at the declared floor, which nothing did before.
+          # Named literally rather than as oldrel-2, which is 4.4.3 and
+          # drifts: a base function added in 4.4.1 would pass CI and fail at
+          # the floor. Update this whenever DESCRIPTION's Depends changes --
+          # the floor-consistency job below fails if the two disagree in the
+          # direction that matters.
+          #
+          # Note what this job cannot do. Installing rejects a floor set
+          # ABOVE the running R and accepts any floor BELOW it, so no matrix
+          # of R versions detects a floor that is too low, which is the whole
+          # of FSSgam_package#31. That is the floor-consistency job's work.
+          - {os: ubuntu-latest,   r: '4.4.0'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -47,3 +60,39 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+
+  # The check R CMD check cannot make: whether DESCRIPTION's declared
+  # "Depends: R (>= x)" is reachable given what the hard dependencies
+  # themselves require, transitively. Installing accepts any floor below the
+  # running R, so the matrix above is blind to a floor set too low -- which is
+  # exactly what FSSgam_package#31 reported, and what left "R (>= 3.5)"
+  # standing while mgcv and MuMIn both required R (>= 4.4.0).
+  #
+  # Run against the versions resolved for this job, so a dependency raising
+  # its own floor fails this job rather than going unnoticed until a user
+  # cannot install the package. The script stops if any hard dependency is
+  # not installed, rather than reporting a floor derived from part of the
+  # closure.
+  r-floor-consistency:
+    runs-on: ubuntu-latest
+    name: declared R floor is reachable
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      # The script reads each dependency's own DESCRIPTION, so they have to be
+      # installed, and it stops rather than passing if any is not. needs: check
+      # installs more than it reads -- Suggests included -- which is harmless.
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: check
+
+      - name: Compare the declared floor against the dependency closure
+        run: Rscript tools/check-r-floor.R

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,10 +59,52 @@ the permanent, citable reference and must not be modified.
 Dependencies are defined in `DESCRIPTION` (Imports + Suggests). Read that file
 to determine what is available — don't assume this list stays in sync.
 
-- **Imports**: `doSNOW`, `foreach`, `gamm4`, `mgcv`, `MuMIn`, `nnet`,
-  `parallel`, `stats`, `utils`
-- **Suggests**: `covr`, `testthat (>= 3.1.5)`
-- **Depends**: `R (>= 3.5)` only — no other package may go in `Depends`
+- **Imports**: `doSNOW`, `foreach`, `mgcv`, `MuMIn`, `nnet`, `parallel`,
+  `stats`, `utils`
+- **Suggests**: `covr`, `gamm4`, `testthat (>= 3.1.5)`. `gamm4` moved out of
+  `Imports` so that a parallel worker no longer loads it and `lme4` with it
+  for every model set (FSSgam_package#14).
+- **Depends**: `R (>= 4.4.0)` only — no other package may go in `Depends`.
+  The floor is not chosen: `MuMIn` and `mgcv` both declare
+  `Depends: R (>= 4.4.0)`, so nothing lower is reachable.
+
+  Two jobs in `.github/workflows/R-CMD-check.yaml` cover it, and they check
+  different things. The `r: '4.4.0'` matrix entry establishes that the
+  package installs and passes on an R at the declared floor. The
+  `r-floor-consistency` job runs `tools/check-r-floor.R`, which compares the
+  declared floor against the `Depends` of every hard dependency, walking the
+  closure rather than the direct `Imports`, and fails if the declared one is
+  lower. The closure matters: `Matrix` declares `R (>= 4.4)` and arrives only
+  through `mgcv` and `MuMIn`, so a check of the direct `Imports` misses it.
+
+  The script stops rather than reporting success in three cases where it
+  cannot count a constraint: a dependency that is not installed, an R
+  constraint in a form it does not parse, and a `DESCRIPTION` with no floor.
+  Each was added after review found it in turn silently passing, and a fourth
+  round found the guards themselves ordered wrongly — an empty-closure exit
+  placed above the uninstalled-dependency check accepted the declared floor,
+  having read nothing, for a package all of whose dependencies were missing.
+  **Anything added here must fail loudly rather than contribute no floor, and
+  must be placed above the reporting, not below it** — that is the failure
+  mode the script exists to catch, and it recurred four times inside the
+  script itself.
+
+  **Only the second detects the defect FSSgam_package#31 reported.**
+  Installing rejects a floor set above the running R and accepts any floor
+  below it, so no matrix of R versions sees a floor that is too low.
+  Measured 2026-09-03 on this host: `R CMD INSTALL` and `devtools::check()`
+  both succeed with `Depends: R (>= 3.5)` on R 4.6.1. No CI run was made
+  against a reverted `DESCRIPTION`; that every matrix job would stay green
+  follows from what installation does, and is an inference rather than a
+  measurement. Do not add an R version to the matrix and take it for a floor
+  check.
+
+  `DESCRIPTION` records no provenance comment. Writing R Extensions §1.1.1
+  states the format does not support `#` comments, and any `desc`-based write
+  deletes them silently -- `usethis::use_package()`, a version bump, and
+  `roxygen2::roxygenise()` updating `Config/roxygen2/version` all do, and this
+  repository has run two of the three. `tools/check-r-floor.R` holds the
+  provenance instead, where it is executed rather than trusted.
 
 `doSNOW` is not installed by default in fresh environments (e.g. this WSL
 container) even though it's a long-standing declared dependency — ask before
@@ -130,6 +172,12 @@ planning/                 # the two planning documents for the 1.1.0 pre-CRAN re
                           # CLAUDE.md Section 13) plus golden-master/, the before/after
                           # comparison scripts that phase was verified with. Tracked in git
                           # and .Rbuildignore'd, so none of it reaches the built package.
+tools/
+  check-r-floor.R         # compares DESCRIPTION's declared Depends: R (>= x) against the
+                          # closure of the hard dependencies and fails if it is not
+                          # reachable. Run by the r-floor-consistency job in
+                          # .github/workflows/R-CMD-check.yaml, not by R CMD check.
+                          # Tracked in git and .Rbuildignore'd (Section 3, Section 5)
 ```
 
 ---
@@ -686,14 +734,17 @@ Points to note before extending the suite again:
   as they stand: the two beckyfisher/FSSgam#10/#12 family resolution tests,
   the two `full_subsets_gam()` Phase 7 regression tests, and everything in
   `test-deprecated.R`.
-- **The tests may not use `deparse1()`.** It arrived in R 4.0.0 and
-  `DESCRIPTION` declares `R (>= 3.5)`, so the suite has to run without it.
-  `deparse_one()` in `helper-fixtures.R` is the replacement, and matches
-  `deparse1()`'s `width.cutoff = 500L`. `deparse()`'s own default of 60
-  wraps 8 of the 39 formulas across three representative candidate sets,
-  and a wrapped formula deparses to a different string, so the cutoff
-  matters. `testthat (>= 3.1.5)` is declared for the same class of reason:
-  `expect_no_warning()` arrived in that version.
+- **Deparse formulas with `deparse1()`, not `deparse()`.** `deparse()`'s
+  default `width.cutoff` of 60 wraps 8 of the 39 formulas across three
+  representative candidate sets, and a wrapped formula deparses to a
+  different string, so the cutoff matters; `deparse1()` uses 500. The suite
+  used a local `deparse_one()` while `deparse1()` could not be called: it
+  arrived in R 4.0.0 and the declared floor was `R (>= 3.5)`. That floor was
+  not reachable in the first place and has been raised
+  (FSSgam_package#31), so `deparse1()` is now used directly and
+  `deparse_one()` no longer exists. `testthat (>= 3.1.5)`
+  is declared for a related reason: `expect_no_warning()` arrived in that
+  version.
 - **The numerical snapshots run everywhere, with one exclusion.** The
   binomial `gamm4`/`uGamm` scenario omits `edf` from its numeric snapshot,
   because gamm4 reports a smooth's edf through lme4's random-effect

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description:
     interactions via te(). Methods are described in
     Fisher et al. (2018) <doi:10.1002/ece3.4134>.
 Depends:
-    R (>= 3.5)
+    R (>= 4.4.0)
 License: Apache License (== 2.0)
 Encoding: UTF-8
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,37 @@
 # FSSgam (development version)
 
+* **`DESCRIPTION` now declares `Depends: R (>= 4.4.0)`, raised from
+  `R (>= 3.5)`.** The old floor was not reachable: `MuMIn` and `mgcv`, both
+  hard `Imports`, each declare `Depends: R (>= 4.4.0)` at the versions current
+  when this was measured (MuMIn 1.48.19, mgcv 1.9-4), so the package could not
+  be installed on anything lower whatever this field said. Nothing about what
+  the package can do changes; the declaration now states what was already true.
+  A user pinned to an older `MuMIn` and `mgcv` may find the new floor excludes
+  a configuration that did work, which is the reason the change is noted here
+  rather than treated as a correction (FSSgam_package#31).
+
+  The floor is now checked rather than asserted. `tools/check-r-floor.R`
+  compares the declared floor against the `Depends` of every hard dependency,
+  transitively, and fails if the declared one is lower; it runs in CI as a new
+  `r-floor-consistency` job. The closure matters: `Matrix` declares
+  `R (>= 4.4)` and is not a direct dependency of this package, arriving through
+  `mgcv` and `MuMIn`, so a check of the direct `Imports` alone would miss it. The
+  script also stops rather than passing wherever it cannot count a constraint:
+  a dependency that is not installed, an R constraint written in a form it does
+  not read, and a `DESCRIPTION` declaring no floor at all. `.github/workflows/R-CMD-check.yaml` also gains an
+  `ubuntu-latest`, `R 4.4.0` matrix entry, so the package is built, installed
+  and tested on an R at the declared floor for the first time.
+
+  The two check different things, and only the first detects what was wrong
+  here. Installing a package rejects a floor set above the running R and
+  accepts any floor below it, so no matrix of R versions can see a floor that
+  is too low: reverting `DESCRIPTION` to `R (>= 3.5)` leaves every matrix job
+  green.
+
+  Consequently the test suite uses `deparse1()` directly and the local
+  `deparse_one()` in `tests/testthat/helper-fixtures.R`, which existed only
+  because `deparse1()` arrived in R 4.0.0, is removed.
+
 * `fit_model_set()`'s `r2.vals.unique` column is now documented. It was returned
   in `mod.data.out` and described nowhere. The documentation states that the
   column is the model R2 minus the null model's R2, so it is the variance

--- a/planning/pre-cran-refactor-claude.md
+++ b/planning/pre-cran-refactor-claude.md
@@ -363,9 +363,13 @@ character vector; 8. `factor.smooth.interactions` as a list; 9.
 16. a single predictor.
 
 Scenarios 15 and 16 will differ after phase 4 and must be captured again at
-that point. Use `deparse_one()` from `helper-fixtures.R`, not `deparse()` — its
-default `width.cutoff` of 60 wraps long formulas and a wrapped formula
-deparses to a different string.
+that point. Use `deparse1()`, not `deparse()` — the latter's default
+`width.cutoff` of 60 wraps long formulas and a wrapped formula deparses to a
+different string. This said `deparse_one()`, a local helper in
+`helper-fixtures.R` that existed only because `deparse1()` postdated the
+declared R floor. The floor was raised and the helper deleted
+(FSSgam_package#31); `planning/golden-master/capture.R` still defines its own
+copy and is left alone, being a self-contained record of what was run.
 
 ---
 

--- a/prompts/open-issues-batched-fixes.md
+++ b/prompts/open-issues-batched-fixes.md
@@ -168,3 +168,240 @@ they would have had to use to succeed. Not fixed here: whether to support it, or
 to document `uGamm` as the only route to a mixed fit, is a decision.
 
 ---
+**Claude:** Batch 2 (FSSgam_package#31), branch `batch2-r-version-floor`, stacked
+on batch 1.
+
+The declared floor `R (>= 3.5)` was not reachable. The issue names `MuMIn`;
+`mgcv` was found to declare the same thing, so both hard `Imports` require
+R 4.4.0 and the floor was raised to match. Measured at MuMIn 1.48.19 and
+mgcv 1.9-4:
+
+```
+MuMIn    Depends: R (>= 4.4.0)
+mgcv     Depends: R (>= 4.4.0), nlme (>= 3.1-64)
+doSNOW   Depends: R (>= 2.5.0), ...
+foreach  Depends: R (>= 2.5.0)
+nnet     Depends: R (>= 3.0.0), ...
+testthat Depends: R (>= 4.1.0)          [Suggests]
+```
+
+The issue poses two decisions. The first is whether the floor should track the
+hard dependencies: it should, and does. The second is whether anything should
+check it, since `R CMD check` does not verify a declared floor against a
+dependency's. Two things now do, rather than the comment alone the issue
+proposed:
+
+- A comment in `DESCRIPTION` recording that the floor is derived and not chosen.
+  Confirmed that `read.dcf()` ignores `#` lines, that `R CMD check` passes with
+  it, and that `R CMD build` strips it from the tarball's `DESCRIPTION`, so the
+  provenance stays in the source where a reader of the repository finds it and
+  never reaches CRAN.
+- An `ubuntu-latest`, `oldrel-2` job in `.github/workflows/R-CMD-check.yaml`.
+  With the release at 4.6, `oldrel-2` is 4.4, which is the declared floor. It is
+  written as `oldrel-2` rather than as `4.4` so it needs no maintenance, with a
+  comment recording that it stops testing the floor once R moves past 4.6. This
+  is more than the issue asked for and is the part most easily dropped if the
+  job proves unreliable; the comment alone still records the provenance.
+
+Consequences carried out with it: `deparse_one()` in
+`tests/testthat/helper-fixtures.R` existed only because `deparse1()` arrived in
+R 4.0.0, so it was deleted and its 31 call sites across four test files replaced
+with `deparse1()`. `CLAUDE.md`'s note recording that constraint was rewritten,
+as was its `Depends` line. Its `Imports`/`Suggests` list was also corrected while
+adjacent: it still listed `gamm4` under `Imports`, which stopped being true when
+`gamm4` moved to `Suggests`.
+
+Not done: `parallel::makePSOCKcluster(setup_strategy = "sequential")` is now
+available as a mitigation to test against FSSgam_package#14, having been
+rejected partly on the old floor. That belongs to batch 6.
+
+---
+**Review cycle 1 (independent session, batch 2).** Three substantive findings.
+The floor value itself was confirmed correct — 4.4.0 across the whole installed
+dependency closure, nothing in `R/` or `tests/` using anything added after
+R 4.0.0 — and the `deparse1()` substitution exact. All three defects were in the
+two mechanisms meant to record and check the floor, and all three were
+reproduced here before being acted on.
+
+- **The `oldrel-2` job could not detect the defect FSSgam_package#31 reported.**
+  Installing a package rejects a floor set *above* the running R and accepts any
+  floor *below* it, so no matrix of R versions sees a floor that is too low.
+  Confirmed: `R CMD INSTALL` of a copy with `Depends: R (>= 3.5)` succeeds on
+  R 4.6.1. Four documents said the job checked the floor. Replaced with
+  `tools/check-r-floor.R`, which compares the declared floor against the
+  `Depends` of every hard dependency and exits 1 on exactly the state the issue
+  reported, run in CI as an `r-floor-consistency` job. The matrix entry is kept
+  but described accurately, as establishing that the package installs and passes
+  at the declared floor.
+
+  This is the finding worth carrying forward: **an R version in the CI matrix is
+  not a floor check.** It tests the opposite direction from the one that goes
+  wrong.
+
+- **The `DESCRIPTION` comment is deleted by routine tooling.** Any `desc`-based
+  write removes it — `usethis::use_package()`, a version bump,
+  `roxygen2::roxygenise()` updating `Config/roxygen2/version` — and this
+  repository has run two of the three. Writing R Extensions §1.1.1 also states
+  the format does not support `#` comments; `read.dcf()` skipping them is an
+  implementation detail, not a guarantee. The comment was removed and the
+  provenance moved into the script, where it is executed rather than trusted.
+
+- **`oldrel-2` resolves to 4.4.3, not 4.4.0.** A base function added in 4.4.1
+  would pass CI and fail at the declared floor. The matrix entry now names 4.4.0
+  literally. The stated reason for `oldrel-2`, that it needed no maintenance,
+  also contradicted its own comment saying to re-check it when R moves past 4.6.
+
+Minor points acted on: the PR evidence table was headed "every dependency" while
+covering only the direct ones; bare `#14` where `beckyfisher/FSSgam#14` also
+exists; and `planning/pre-cran-refactor-claude.md` still directed a future
+session to the deleted `deparse_one()`. `planning/golden-master/capture.R`
+defines its own copy and was left alone, being a self-contained record of what
+was run. A comment was added to FSSgam_package#14 recording that the constraint
+on its `setup_strategy` mitigation is lifted.
+
+---
+**Review cycle 2 (independent session, batch 2).** Two substantive findings, both
+silent-pass paths in `tools/check-r-floor.R` — the same defect class cycle 1
+found in the CI matrix entry, one level down. Both reproduced here before being
+acted on.
+
+- **The script read only the direct `Imports` and printed "OK".** `Matrix`
+  declares `R (>= 4.4)` and `MASS` declares `R (>= 4.4.0)`, and neither is a
+  direct dependency of this package: both arrive through `mgcv`, `MuMIn` and
+  `gamm4`. Reproduced: a `DESCRIPTION` with `Imports: gamm4, nnet` and
+  `Depends: R (>= 3.5)` exited 0 under the old script and exits 1 under the new
+  one, naming `MASS, Matrix, mgcv`. The script now walks the transitive closure
+  of `Depends`, `Imports` and `LinkingTo`, excluding only base-priority packages
+  — recommended packages are where the binding floor is actually found.
+
+- **An uninstalled dependency contributed no floor and the job stayed green.**
+  `packageDescription()` returns `NA`, `$Depends` errors, the `tryCatch`
+  swallowed it and the row printed as `-`. This repository's `CLAUDE.md` §3
+  records that exact state for `doSNOW`. The script now stops, naming the
+  packages it could not read.
+
+The minor finding that a package moved from `Imports` to `Depends` would be
+unread was fixed with them: the seed set is now `Depends` + `Imports` +
+`LinkingTo`.
+
+Nine edge cases were constructed and run against the rewritten script, since it
+is the only new code in this batch: the floor written `R (>=4.4.0)` and
+`R(>= 4.4.0)` without the usual spaces; `R (>= 4.4)` against `R (>= 4.4.0)`,
+which must compare equal and do so because `package_version()` pads;
+`R (>= 4.10.0)` against `R (>= 4.9.0)`, which string comparison would order
+wrongly and `package_version()` does not; version constraints on the `Imports`
+entries; a hard dependency declared in `Depends` rather than `Imports`; a
+`DESCRIPTION` with no R floor at all; an uninstalled dependency; and package
+names beginning with R -- `Rcpp`, `R6` -- which must not be read as the R entry
+and are not, the pattern being anchored on `R` followed by `(`.
+
+---
+**Review cycle 3 (independent session, batch 2).** One substantive finding: the
+third instance of the same failure mode, this time inside the script written to
+catch it.
+
+`read_r_floor()` returned `NULL` both for a dependency declaring no R constraint
+and for one whose constraint it could not parse. It accepted only `>=`, so any
+other operator fell through, printed as `-` — the same glyph as "declares
+nothing" — and contributed no floor. Reproduced with a scratch dependency
+declaring `Depends: R (<= 9.9.0)`: the script printed "No hard dependency
+declares an R floor; nothing to check" and exited 0. The form exists in
+practice; the reviewer found `R (> 3.0.2)` among 818 R constraints across the
+1119 packages installed here.
+
+Rewritten as `parse_r_constraint()`, returning one of three states rather than
+two: `none`, `ok`, `unparsed`. `>` is now read as well as `>=`, since
+`R (> 3.0.2)` means at least that version and understates the true floor by at
+most a patch level, which is safe in this direction. Anything else stops the
+script naming the package and the constraint. Verified with three scratch
+packages installed for the purpose: `R (> 4.5.9)` is counted as a floor of 4.5.9
+and fails a declared 3.5; `R (<= 9.9.0)` stops the script; `Depends: methods`
+reaches the "nothing to check" path legitimately.
+
+**Three statements of mine were false and are corrected.** They are recorded here
+because each was asserted in several places at once:
+
+- *`MASS` declares `R (>= 4.4.0)` and arrives through `mgcv`, `MuMIn` and
+  `gamm4`.* It arrives only through `gamm4` → `lme4`, and `gamm4` is a
+  `Suggests`, which the script does not walk. `MASS` is not in this package's
+  hard closure and does not appear in the script's own output. `Matrix` alone
+  justifies the closure walk, so the argument survives, but the sentence was in
+  the script, `NEWS.md`, `CLAUDE.md`, the commit message and the pull request
+  body.
+- *Neither new CI job has run yet.* Both had run and passed on `51b296e`.
+  Recorded below with the job names.
+- The pull request body quoted an error message the script no longer emits.
+
+The empty-closure path also crashed at `order(names(rows))` for a package with
+no hard dependencies outside base R, and now exits cleanly.
+
+**Both new CI jobs pass.** Run 33721973950 on `51b296e`: `declared R floor is
+reachable: success`, `ubuntu-latest (4.4.0): success`, alongside the four
+pre-existing matrix jobs. This confirms two things that could not be checked
+locally: that `r-lib/actions` resolves a literal `4.4.0`, and that the script
+runs against a dependency set installed by `setup-r-dependencies` rather than
+this host's.
+
+---
+**Review cycle 4 (independent session, batch 2).** One substantive finding: the
+fourth instance, this time in the ordering of the guards rather than in any one
+of them.
+
+The empty-closure exit added in cycle 3 was placed *above* the
+uninstalled-dependency check added in cycle 2. `rows` is empty exactly when no
+dependency could be read, so a package all of whose hard dependencies were
+missing reached `quit(status = 0)` reporting "This package declares no hard
+dependencies outside base R" — while declaring two — and accepted the declared
+floor having read nothing. Reproduced with `Imports: notinstalledA,
+notinstalledB, stats` and `Depends: R (>= 3.5)`: exit 0 before, exit 1 after.
+
+The reporting section was restructured so that every guard runs before any exit
+path, with a comment saying so and why. Eight cases were then re-run: all
+dependencies uninstalled, one uninstalled, genuinely no hard dependencies, an
+unparsed constraint, a strict `>` constraint, a dependency declaring no R floor,
+the FSSgam_package#31 state, and the package as it stands. All eight behave
+correctly.
+
+Two smaller defects fixed with it: a table row vanished entirely rather than
+printing a blank where a field was zero-length, `sprintf()` returning
+`character(0)` if any argument is; and the advisory to record why a floor is
+higher than its dependencies require was unreachable on the no-floors path.
+
+Two documentation corrections. `CLAUDE.md` labelled as "Measured" the statement
+that reverting `DESCRIPTION` would leave every CI job green — no such CI run was
+made, and it is an inference from `R CMD INSTALL` and `devtools::check()` on this
+host. `NEWS.md` named two of the three cases in which the script stops where two
+other documents named three.
+
+The reviewer also ran `parse_r_constraint()` over every R constraint declared by
+every package installed on this host — 1119 constraint rows across 813 packages —
+and none was classified unparsed, so the parser meets the population it will
+actually see.
+
+---
+**Review cycle 5 (independent session, batch 2).** No substantive finding, and no
+fifth instance. That session traced every exit path and ran 20 constructed
+inputs — the eight from cycle 4 plus a tie at the binding floor, a transitive
+chain, a dependency cycle, a missing `Version` field, `R6`/`Rcpp` names, a
+constraint on a DCF continuation line, a CRLF `DESCRIPTION`, both
+own-`DESCRIPTION` guards, and the advisory path — all correct.
+
+One low finding was worth acting on rather than accepting. `R (> x)` was read as
+a floor of `x`, conflating it with `R (>= x)`, and the comment called the
+resulting understatement "safe in this direction", which is inverted: a declared
+floor of exactly `x` satisfies `>= x` and does not satisfy `> x`, so the check
+could pass a floor one patch level too low. Rather than document the
+approximation, the operator is now recorded and each constraint tested as
+written, which removes it. The maximum is still computed, but only for the
+report. Verified with a scratch dependency declaring `R (> 4.4.0)`: a declared
+`R (>= 4.4.0)` now fails and `R (>= 4.4.1)` passes.
+
+`tools/` was added to the directory tree in `CLAUDE.md` §4, which two earlier
+rounds had raised, and four prose items were corrected.
+
+Two claims in the cycle 4 response were wrong and were corrected before posting:
+the constraint population is 818 R constraints, not 1119, which is the
+`installed.packages()` row count; and "covering every path through the script"
+omitted three exit paths, which cycle 5 verified separately.
+
+---

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -237,13 +237,6 @@ break_one_candidate <- function(model.set, modname = "ZONE+depth") {
   model.set
 }
 
-# One-line deparse of a formula or call, with the same joining behaviour as
-# deparse1(): width.cutoff = 500L, and a space between any lines that still wrap.
-#
-# deparse1() would do this, but it was added in R 4.0.0 and DESCRIPTION declares
-# R (>= 3.5). The tests must run on the declared minimum, so they cannot use it.
-deparse_one <- function(x) paste(deparse(x, width.cutoff = 500L), collapse = " ")
-
 # Muffles only nnet's "NaNs produced" warning, leaving every other warning to
 # reach the test.
 #

--- a/tests/testthat/test-functions_supporting.R
+++ b/tests/testthat/test-functions_supporting.R
@@ -249,7 +249,7 @@ test_that("fit_mod_l refits a gamm4 test.fit", {
   )
 
   expect_s3_class(updated, "gamm4")
-  expect_match(deparse_one(stats::formula(updated$gam)), "av.wave", fixed = TRUE)
+  expect_match(deparse1(stats::formula(updated$gam)), "av.wave", fixed = TRUE)
 })
 
 test_that("fit_mod_l accepts an explicitly supplied family", {

--- a/tests/testthat/test-generate_model_set.R
+++ b/tests/testthat/test-generate_model_set.R
@@ -167,7 +167,7 @@ test_that("no phantom by-term survives into the model set at higher max.predicto
   )
 
   expect_false(any(grepl("NA.by.", names(model.set$mod.formula), fixed = TRUE)))
-  formulas <- vapply(model.set$mod.formula, deparse_one, character(1))
+  formulas <- vapply(model.set$mod.formula, deparse1, character(1))
   expect_false(any(grepl("s(NA", formulas, fixed = TRUE)))
   expect_setequal(
     names(model.set$mod.formula),
@@ -259,7 +259,7 @@ test_that("factor.smooth.interactions as a list gives per-predictor-type control
   # SCORE2 was named as a linear.var, so it gets a .t. (product) interaction
   expect_true("SCORE2.t.ZONE+ZONE" %in% mod.names)
   expect_match(
-    deparse_one(model.set$mod.formula[["SCORE2.t.ZONE+ZONE"]]), "SCORE2 * ZONE",
+    deparse1(model.set$mod.formula[["SCORE2.t.ZONE+ZONE"]]), "SCORE2 * ZONE",
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-generate_model_set_formulas.R
+++ b/tests/testthat/test-generate_model_set_formulas.R
@@ -17,11 +17,11 @@ test_that("cyclic.vars substitutes bs='cc' into main-effect smooths", {
   )
 
   expect_equal(
-    deparse_one(model.set$mod.formula[["lunar.date"]]),
+    deparse1(model.set$mod.formula[["lunar.date"]]),
     "~s(lunar.date, k = 5, bs = \"cc\")"
   )
   expect_equal(
-    deparse_one(model.set$mod.formula[["month"]]),
+    deparse1(model.set$mod.formula[["month"]]),
     "~s(month, k = 5, bs = \"cc\")"
   )
 })
@@ -38,8 +38,8 @@ test_that("cyclic.vars leaves non-cyclic continuous predictors on bs.arg", {
     k = 5
   )
 
-  expect_match(deparse_one(model.set$mod.formula[["lunar.date"]]), "bs = \"cc\"", fixed = TRUE)
-  expect_match(deparse_one(model.set$mod.formula[["gwt"]]), "bs = \"cr\"", fixed = TRUE)
+  expect_match(deparse1(model.set$mod.formula[["lunar.date"]]), "bs = \"cc\"", fixed = TRUE)
+  expect_match(deparse1(model.set$mod.formula[["gwt"]]), "bs = \"cr\"", fixed = TRUE)
 })
 
 test_that("cyclic.vars substitutes bs='cc' into factor-smooth (by) terms", {
@@ -58,7 +58,7 @@ test_that("cyclic.vars substitutes bs='cc' into factor-smooth (by) terms", {
   by.name <- grep(".by.", names(model.set$mod.formula), fixed = TRUE, value = TRUE)
   expect_length(by.name, 1)
   expect_match(
-    deparse_one(model.set$mod.formula[[by.name]]),
+    deparse1(model.set$mod.formula[[by.name]]),
     "s(lunar.date, by = Sex, k = 5, bs = \"cc\")",
     fixed = TRUE
   )
@@ -78,7 +78,7 @@ test_that("a te() of two cyclic predictors gets bs=c('cc','cc')", {
   )
 
   expect_equal(
-    deparse_one(model.set$mod.formula[["lunar.date.te.month"]]),
+    deparse1(model.set$mod.formula[["lunar.date.te.month"]]),
     "~te(lunar.date, month, k = 5, bs = c(\"cc\", \"cc\"))"
   )
 })
@@ -98,7 +98,7 @@ test_that("a te() mixing a cyclic and a non-cyclic predictor gets bs=c('cc','cr'
 
   # the te() marginal bases follow the order the predictors appear in the term
   expect_equal(
-    deparse_one(model.set$mod.formula[["lunar.date.te.gwt"]]),
+    deparse1(model.set$mod.formula[["lunar.date.te.gwt"]]),
     "~te(lunar.date, gwt, k = 5, bs = c(\"cc\", \"cr\"))"
   )
 })
@@ -135,10 +135,10 @@ test_that("linear.vars appear as bare linear terms, not smooths", {
   )
 
   expect_equal(
-    deparse_one(model.set$mod.formula[["SCORE2"]]),
+    deparse1(model.set$mod.formula[["SCORE2"]]),
     "~SCORE2 + s(site, bs = \"re\")"
   )
-  expect_false(grepl("s(SCORE2", deparse_one(model.set$mod.formula[["SCORE2"]]), fixed = TRUE))
+  expect_false(grepl("s(SCORE2", deparse1(model.set$mod.formula[["SCORE2"]]), fixed = TRUE))
 })
 
 test_that("linear.vars interact with factors as a product term", {
@@ -151,7 +151,7 @@ test_that("linear.vars interact with factors as a product term", {
 
   expect_true("SCORE2.t.ZONE+ZONE" %in% names(model.set$mod.formula))
   expect_equal(
-    deparse_one(model.set$mod.formula[["SCORE2.t.ZONE+ZONE"]]),
+    deparse1(model.set$mod.formula[["SCORE2.t.ZONE+ZONE"]]),
     "~SCORE2 * ZONE + ZONE + s(site, bs = \"re\")"
   )
 })
@@ -167,11 +167,11 @@ test_that("a continuous predictor named in both pred.vars.cont and linear.vars i
   )
 
   expect_equal(
-    deparse_one(model.set$mod.formula[["depth"]]),
+    deparse1(model.set$mod.formula[["depth"]]),
     "~depth + s(site, bs = \"re\")"
   )
   expect_match(
-    deparse_one(model.set$mod.formula[["complexity"]]), "s(complexity", fixed = TRUE
+    deparse1(model.set$mod.formula[["complexity"]]), "s(complexity", fixed = TRUE
   )
 
   # This configuration is also the one that exercises enumerate_candidate_models()'s
@@ -182,7 +182,7 @@ test_that("a continuous predictor named in both pred.vars.cont and linear.vars i
   # fit_model_set() would fit and weight the same model twice.
   expect_equal(anyDuplicated(names(model.set$mod.formula)), 0L)
   expect_equal(
-    anyDuplicated(vapply(model.set$mod.formula, deparse_one, character(1))), 0L
+    anyDuplicated(vapply(model.set$mod.formula, deparse1, character(1))), 0L
   )
 })
 
@@ -195,7 +195,7 @@ test_that("a model set can be built from linear.vars alone", {
   )
   out <- fit_quietly(model.set, parallel = FALSE)
 
-  expect_false(any(grepl("s(complexity", unlist(lapply(model.set$mod.formula, deparse_one)),
+  expect_false(any(grepl("s(complexity", unlist(lapply(model.set$mod.formula, deparse1)),
                           fixed = TRUE)))
   expect_length(out$failed.models, 0)
 })
@@ -217,11 +217,11 @@ test_that("every linear.vars entry gets its own factor interaction term", {
   )
 
   expect_equal(
-    deparse_one(model.set$mod.formula[["ZONE+complexity.t.ZONE"]]),
+    deparse1(model.set$mod.formula[["ZONE+complexity.t.ZONE"]]),
     "~complexity * ZONE + ZONE + s(site, bs = \"re\")"
   )
   expect_equal(
-    deparse_one(model.set$mod.formula[["SCORE2.t.ZONE+ZONE"]]),
+    deparse1(model.set$mod.formula[["SCORE2.t.ZONE+ZONE"]]),
     "~SCORE2 * ZONE + ZONE + s(site, bs = \"re\")"
   )
 })
@@ -244,7 +244,7 @@ test_that("a list-form factor.smooth.interactions still fits its linear interact
 
   expect_true("ZONE+depth.t.ZONE" %in% names(model.set$mod.formula))
   expect_equal(
-    deparse_one(model.set$mod.formula[["ZONE+depth.t.ZONE"]]),
+    deparse1(model.set$mod.formula[["ZONE+depth.t.ZONE"]]),
     "~depth * ZONE + ZONE + s(site, bs = \"re\")"
   )
 })
@@ -253,7 +253,7 @@ test_that("a list-form factor.smooth.interactions still fits its linear interact
 
 test_that("bs.arg controls the basis of every smooth term", {
   model.set <- fixture_cs1_model_set(bs.arg = "'ts'")
-  formulas <- unlist(lapply(model.set$mod.formula, deparse_one))
+  formulas <- unlist(lapply(model.set$mod.formula, deparse1))
 
   smooths <- formulas[grepl("s(complexity", formulas, fixed = TRUE) |
                              grepl("s(depth", formulas, fixed = TRUE)]
@@ -275,14 +275,14 @@ test_that("a non-default bs.arg still produces a fittable model set", {
 test_that("null.terms = '' gives an intercept-only null and no appended term", {
   model.set <- fixture_cs1_model_set(null.terms = "")
 
-  expect_equal(deparse_one(model.set$mod.formula[["null"]]), "~1")
-  expect_false(any(grepl("bs = \"re\"", unlist(lapply(model.set$mod.formula, deparse_one)),
+  expect_equal(deparse1(model.set$mod.formula[["null"]]), "~1")
+  expect_false(any(grepl("bs = \"re\"", unlist(lapply(model.set$mod.formula, deparse1)),
                           fixed = TRUE)))
 })
 
 test_that("null.terms is appended to every candidate formula", {
   model.set <- fixture_cs1_model_set()
-  formulas <- unlist(lapply(model.set$mod.formula, deparse_one))
+  formulas <- unlist(lapply(model.set$mod.formula, deparse1))
 
   expect_true(all(grepl("s(site, bs = \"re\")", formulas, fixed = TRUE)))
 })
@@ -309,8 +309,8 @@ test_that("a gamm4 test.fit produces t2() rather than te() smooth-smooth interac
 
   te.name <- grep(".te.", names(model.set$mod.formula), fixed = TRUE, value = TRUE)
   expect_length(te.name, 1)
-  expect_match(deparse_one(model.set$mod.formula[[te.name]]), "^~t2\\(")
-  expect_false(grepl("te(", deparse_one(model.set$mod.formula[[te.name]]), fixed = TRUE))
+  expect_match(deparse1(model.set$mod.formula[[te.name]]), "^~t2\\(")
+  expect_false(grepl("te(", deparse1(model.set$mod.formula[[te.name]]), fixed = TRUE))
 })
 
 # ---- cyclic.vars are matched by name, not by substring ----------------------
@@ -333,7 +333,7 @@ test_that("a cyclic variable does not make a longer name cyclic too", {
     max.predictors = 1, k = 4
   )
 
-  f <- vapply(model.set$mod.formula, deparse_one, character(1))
+  f <- vapply(model.set$mod.formula, deparse1, character(1))
   expect_match(f[["depth"]], "s(depth, k = 4, bs = \"cc\")", fixed = TRUE)
   expect_match(f[["depthx"]], "s(depthx, k = 4, bs = \"cr\")", fixed = TRUE)
   expect_match(f[["complexity"]], "s(complexity, k = 4, bs = \"cr\")", fixed = TRUE)
@@ -356,7 +356,7 @@ test_that("a full stop in a predictor name is not treated as a wildcard", {
     null.terms = "s(site,bs='re')", max.predictors = 1, k = 4
   )
 
-  f <- vapply(model.set$mod.formula, deparse_one, character(1))
+  f <- vapply(model.set$mod.formula, deparse1, character(1))
   expect_match(f[["a.b"]], "bs = \"cc\"", fixed = TRUE)
   expect_match(f[["axb"]], "bs = \"cr\"", fixed = TRUE)
 })
@@ -374,7 +374,7 @@ test_that("a cyclic variable inside a te() pair gets its own basis", {
     max.predictors = 2, k = 4, cov.cutoff = 0.9
   )
 
-  f <- vapply(model.set$mod.formula, deparse_one, character(1))
+  f <- vapply(model.set$mod.formula, deparse1, character(1))
   te.name <- grep(".te.", names(f), fixed = TRUE, value = TRUE)
   expect_length(te.name, 1)
   # month is cyclic and lunar.date is not, in that order
@@ -394,7 +394,7 @@ test_that("a three-way te() carries one basis per marginal", {
     null.terms = "s(site,bs='re')", cov.cutoff = 0.4, max.predictors = 3, k = 3
   )
 
-  f <- vapply(model.set$mod.formula, deparse_one, character(1))
+  f <- vapply(model.set$mod.formula, deparse1, character(1))
   three.way <- grep("depth.te.SCORE2.te.complexity", names(f), fixed = TRUE, value = TRUE)
   expect_length(three.way, 1)
   expect_match(f[[three.way]], "bs = c(\"cr\", \"cr\", \"cr\")", fixed = TRUE)

--- a/tests/testthat/test-numerical-regression.R
+++ b/tests/testthat/test-numerical-regression.R
@@ -52,7 +52,7 @@ snapshot_exact <- function(model.set, out) {
   mdo <- out$mod.data.out[order(out$mod.data.out$modname), ]
   list(
     formulas = vapply(
-      model.set$mod.formula[sort(names(model.set$mod.formula))], deparse_one, character(1)
+      model.set$mod.formula[sort(names(model.set$mod.formula))], deparse1, character(1)
     ),
     modname = mdo$modname,
     delta.AICc = mdo$delta.AICc,

--- a/tools/check-r-floor.R
+++ b/tools/check-r-floor.R
@@ -1,0 +1,204 @@
+# Checks that DESCRIPTION's declared "Depends: R (>= x)" is reachable given what
+# this package's hard dependencies require, transitively.
+#
+# This is the direction R CMD check cannot see. Installing a package rejects a
+# floor set ABOVE the running R and accepts any floor BELOW it, so no matrix of
+# R versions detects a floor that is too low -- which is the whole of
+# FSSgam_package#31, where "R (>= 3.5)" was declared while mgcv and MuMIn both
+# required R (>= 4.4.0). Reverting to 3.5 leaves every R CMD check green.
+#
+# The closure is walked transitively, not just over direct Imports. Matrix
+# declares R (>= 4.4) and is not a direct dependency of this package: it arrives
+# through mgcv and MuMIn. A check of the direct Imports alone therefore counts
+# one fewer package at the binding floor, and would report "reachable" for a
+# floor that is not, for a package whose only route to Matrix is transitive.
+#
+# An uninstalled dependency is an error, not a skip. Silently contributing no
+# floor is the same failure this script exists to catch, one level down, and
+# CLAUDE.md section 3 records that this repository's environments do sometimes
+# lack a declared dependency.
+
+# Returns list(status, floor, raw), where status is one of:
+#   "none"     the field declares no R constraint at all
+#   "ok"       an R constraint that was parsed, floor is a package_version
+#   "unparsed" an R constraint in a form this does not read
+#
+# The three are distinguished deliberately. Returning NULL for both "no R
+# constraint" and "an R constraint I could not read" is how a check comes to
+# report success without having checked, which is the defect this script exists
+# to catch: an unread constraint would print as "-", the same glyph as a package
+# that genuinely declares nothing, and contribute no floor.
+parse_r_constraint <- function(depends) {
+  none <- list(status = "none", floor = NULL, strict = NA, raw = NA_character_)
+  if (is.null(depends) || length(depends) == 0 || all(is.na(depends))) return(none)
+  fields <- trimws(strsplit(depends, ",")[[1]])
+  # Anchored on R immediately followed by "(", so a package named Rcpp or R6 is
+  # not mistaken for the R entry. The space before "(" is optional and is
+  # written both ways in practice.
+  r <- grep("^R[[:space:]]*\\(", fields, value = TRUE)
+  if (length(r) == 0) return(none)
+  raw <- r[1]
+
+  # ">" as well as ">=", and the two are kept apart rather than conflated.
+  # "R (> 4.4.0)" is declared by real packages and does not mean the same as
+  # "R (>= 4.4.0)": a declared floor of exactly 4.4.0 satisfies the second and
+  # not the first. Reading one as the other would understate the requirement,
+  # so the operator is recorded and each constraint is tested as written. Any
+  # other operator is reported rather than guessed at.
+  m <- regmatches(raw, regexec("^R[[:space:]]*\\([[:space:]]*(>=?)[[:space:]]*([^)]*)\\)", raw))[[1]]
+  if (length(m) != 3) return(list(status = "unparsed", floor = NULL, strict = NA, raw = raw))
+  v <- trimws(m[3])
+  if (!grepl("^[0-9]+([.-][0-9]+)*$", v)) return(list(status = "unparsed", floor = NULL, strict = NA, raw = raw))
+  list(status = "ok", floor = package_version(v), strict = identical(m[2], ">"), raw = raw)
+}
+
+# Package names from a Depends/Imports/LinkingTo field, version constraints and
+# the R entry removed.
+dep_names <- function(field) {
+  if (is.null(field) || length(field) == 0 || all(is.na(field))) return(character(0))
+  x <- trimws(strsplit(gsub("[[:space:]]+", " ", field), ",")[[1]])
+  x <- trimws(sub("\\(.*$", "", x))
+  x <- x[nzchar(x)]
+  setdiff(x, "R")
+}
+
+# Base-priority packages ship with R itself and impose no floor of their own.
+# Recommended packages (Matrix, MASS, nlme, mgcv, nnet) are NOT excluded: they
+# are versioned independently and are where the binding floor is found here.
+base_pkgs <- rownames(utils::installed.packages(priority = "base"))
+
+# read.dcf() returns only the fields present, so index by name through a helper
+# rather than directly: a package with no LinkingTo has no such column.
+desc_raw <- read.dcf("DESCRIPTION")[1, ]
+field <- function(name) if (name %in% names(desc_raw)) desc_raw[[name]] else NULL
+
+declared_c <- parse_r_constraint(field("Depends"))
+if (declared_c$status == "unparsed") {
+  stop(sprintf("DESCRIPTION declares \"%s\", which this script does not read. Write it as R (>= x).",
+               declared_c$raw), call. = FALSE)
+}
+if (declared_c$status == "none") stop("DESCRIPTION declares no Depends: R (>= x) floor.", call. = FALSE)
+declared <- declared_c$floor
+
+# Hard dependencies are Depends, Imports and LinkingTo. Suggests is excluded:
+# a Suggests floor does not stop anyone installing the package, so it does not
+# bound this field. Depends is included -- moving a package from Imports to
+# Depends must not disable the check.
+seed <- unique(c(dep_names(field("Depends")), dep_names(field("Imports")),
+                 dep_names(field("LinkingTo"))))
+seed <- setdiff(seed, base_pkgs)
+
+seen <- character(0)
+rows <- list()
+queue <- seed
+missing <- character(0)
+
+while (length(queue) > 0) {
+  p <- queue[1]
+  queue <- queue[-1]
+  if (p %in% seen) next
+  seen <- c(seen, p)
+
+  d <- tryCatch(utils::packageDescription(p), error = function(e) NA)
+  if (length(d) == 1 && is.na(d)) { missing <- c(missing, p); next }
+
+  con <- parse_r_constraint(d$Depends)
+  rows[[p]] <- list(package = p,
+                    version = as.character(d$Version),
+                    direct = p %in% seed,
+                    status = con$status,
+                    raw = con$raw,
+                    strict = con$strict,
+                    floor = con$floor)
+  nxt <- unique(c(dep_names(d$Depends), dep_names(d$Imports), dep_names(d$LinkingTo)))
+  queue <- c(queue, setdiff(nxt, c(seen, base_pkgs)))
+}
+
+cat(sprintf("DESCRIPTION declares R (>= %s)\n\n", declared))
+
+# Every guard runs before any exit path. Ordering matters and has been wrong:
+# an empty-closure exit placed above the uninstalled-dependency check accepted
+# the declared floor, having read nothing, for a package all of whose
+# dependencies were missing -- reporting "no hard dependencies outside base R"
+# when it declared two. That is the failure this script exists to catch,
+# occurring inside it. Add new guards above the reporting, never below it.
+if (length(missing) > 0) {
+  stop(sprintf(paste0("Cannot check the declared floor: %s not installed, so the R version ",
+                      "they declare could not be read. Install the package's hard ",
+                      "dependencies and re-run."),
+               paste(sort(unique(missing)), collapse = ", ")), call. = FALSE)
+}
+
+unread <- Filter(function(x) x$status == "unparsed", rows)
+if (length(unread) > 0) {
+  stop(sprintf(paste0("Cannot check the declared floor: the R constraint of %s is in a form ",
+                      "this script does not read (%s). Extend parse_r_constraint() rather ",
+                      "than letting the constraint go uncounted."),
+               paste(vapply(unread, `[[`, character(1), "package"), collapse = ", "),
+               paste(vapply(unread, `[[`, character(1), "raw"), collapse = "; ")), call. = FALSE)
+}
+
+# Every field is coerced to a length-one string before printing. sprintf()
+# returns character(0) if any argument is zero-length, so a package whose
+# DESCRIPTION omits Version would otherwise drop its whole row from the table
+# rather than printing a blank.
+one <- function(x, blank = "?") if (length(x) == 0 || is.na(x[1])) blank else as.character(x[1])
+
+if (length(rows) > 0) {
+  cat(sprintf("%-14s %-10s %-8s %s\n", "package", "version", "direct", "declared R floor"))
+  for (x in rows[order(names(rows))]) {
+    shown <- switch(x$status,
+                    ok = paste0(if (isTRUE(x$strict)) "> " else ">= ", one(as.character(x$floor))),
+                    none = "-",
+                    unparsed = paste0("UNREAD: ", one(x$raw)))
+    cat(sprintf("%-14s %-10s %-8s %s\n", one(x$package), one(x$version),
+                if (isTRUE(x$direct)) "yes" else "-", shown))
+  }
+} else {
+  cat("This package declares no hard dependencies outside base R.\n")
+}
+
+floors <- Filter(Negate(is.null), lapply(rows, `[[`, "floor"))
+
+if (length(floors) == 0) {
+  cat("\nNo hard dependency declares an R floor, so nothing bounds the declared one\n")
+  cat("from below. Something other than a dependency is imposing it. Record what,\n")
+  cat("so that the next person does not lower it.\n")
+  quit(status = 0)
+}
+
+# package_version compares componentwise and pads, so "4.4" and "4.4.0" compare
+# equal and "4.10.0" is above "4.9.0". A numeric coercion would order the second
+# pair wrongly, and "4.4.0" is not a number at all.
+needed <- floors[[1]]
+for (v in floors) if (v > needed) needed <- v
+
+binding <- names(floors)[vapply(floors, function(v) v == needed, logical(1))]
+cat(sprintf("\n%d hard dependencies, %d of them direct. Highest floor: R (>= %s), from %s\n",
+            length(rows), sum(vapply(rows, function(x) isTRUE(x$direct), logical(1))),
+            needed, paste(sort(binding), collapse = ", ")))
+
+# Each constraint is tested as written rather than against a single computed
+# maximum, so that "> x" and ">= x" are not conflated: a declared floor of
+# exactly x satisfies the second and fails the first.
+satisfied <- vapply(rows, function(x) {
+  if (x$status != "ok") return(TRUE)
+  if (isTRUE(x$strict)) declared > x$floor else declared >= x$floor
+}, logical(1))
+
+if (any(!satisfied)) {
+  unmet <- rows[!satisfied]
+  stop(sprintf(paste0("DESCRIPTION declares R (>= %s), which does not satisfy %s. The ",
+                      "declared floor is not reachable: raise it, or drop the dependency ",
+                      "that imposes the higher one."),
+               declared,
+               paste(vapply(unmet, function(x)
+                 sprintf("%s's %s", x$package, x$raw), character(1)), collapse = ", ")),
+       call. = FALSE)
+}
+if (declared > needed) {
+  cat("\nThe declared floor is above what the dependencies require. That is allowed,\n")
+  cat("but something other than a dependency is imposing it. Record what, so that the\n")
+  cat("next person does not lower it.\n")
+}
+cat("\nOK: the declared floor is reachable.\n")


### PR DESCRIPTION
Stacked on #32. Review that first; this pull request's diff against `dev` will include it until #32 merges.

## What

`DESCRIPTION` declares `Depends: R (>= 4.4.0)`, raised from `R (>= 3.5)`.

Closes #31.

## Why it matters

The old floor was not reachable, so it was a claim about support that no one could act on and nothing checked. Two hard `Imports` require R 4.4.0 in their own right, so the package could not be installed on anything lower whatever `DESCRIPTION` said.

The floor is not inert. It shapes the code and is used to reject alternatives: the test suite avoided `deparse1()` on account of it, and `parallel::makePSOCKcluster(setup_strategy = "sequential")` was rejected as a mitigation for FSSgam_package#14 partly for the same reason. Neither constraint provided any benefit.

Raising it is nonetheless a change a user can feel. Someone pinned to an older `MuMIn` and `mgcv` may have a working configuration that the new floor excludes, which is why `NEWS.md` states it rather than treating it as a correction.

## Evidence

Declared `Depends` of every direct dependency, measured on this host, R 4.6.1, 2026-09-03. Transitive dependencies were checked separately and none exceeds 4.4.0:

| package | role | `Depends` |
|---|---|---|
| `MuMIn` 1.48.19 | Imports | `R (>= 4.4.0)` |
| `mgcv` 1.9-4 | Imports | `R (>= 4.4.0)`, `nlme (>= 3.1-64)` |
| `doSNOW` 1.0.20 | Imports | `R (>= 2.5.0)`, … |
| `foreach` 1.5.2 | Imports | `R (>= 2.5.0)` |
| `nnet` 7.3-20 | Imports | `R (>= 3.0.0)`, … |
| `gamm4` 0.2-6 | Suggests | `R (>= 2.9.0)`, … |
| `testthat` 3.3.2 | Suggests | `R (>= 4.1.0)` |
| `covr` 3.6.5 | Suggests | `R (>= 3.1.0)`, … |

The binding constraint is 4.4.0, from `MuMIn` **and** `mgcv`. The issue names only `MuMIn`; `mgcv` was found while checking it, and matters because it means the floor does not move if `MuMIn` alone changes.

## The second decision the issue poses

The issue asks whether anything should check the floor, noting that `R CMD check` does not verify a declared floor against a dependency's, and proposing a comment in `DESCRIPTION` as the practical option. Neither the comment nor a CI matrix entry answers it, so this pull request adds a check that does.

**`tools/check-r-floor.R`, run in CI as a new `r-floor-consistency` job.** It reads `DESCRIPTION`'s declared floor, walks the transitive closure of `Depends`, `Imports` and `LinkingTo`, reads each package's own declared R floor as resolved for that job, and fails if the declared floor is lower than the highest of them. Output on this branch:

```
DESCRIPTION declares R (>= 4.4.0)

package        version    direct   declared R floor
codetools      0.2-20     -        2.1
doSNOW         1.0.20     yes      2.5.0
foreach        1.5.2      yes      2.5.0
insight        1.5.2      -        3.6
iterators      1.0.14     -        2.5.0
lattice        0.22-7     -        4.0.0
Matrix         1.7-4      -        4.4
mgcv           1.9-4      yes      4.4.0
MuMIn          1.48.19    yes      4.4.0
nlme           3.1-168    -        3.6.0
nnet           7.3-20     yes      3.0.0
snow           0.4-4      -        2.13.1

12 hard dependencies, 5 of them direct. Highest floor: R (>= 4.4.0), from Matrix, mgcv, MuMIn

OK: the declared floor is reachable.
```

**The closure, not the direct `Imports`.** `Matrix` declares `R (>= 4.4)` and is not a direct dependency of this package, arriving through `mgcv` and `MuMIn`, so a check of the direct `Imports` alone misses one of the three packages at the binding floor. For a package whose only route to `Matrix` is transitive it would report a floor reachable that is not.

**The script stops rather than reporting success wherever it cannot count a constraint.** Three such cases: a dependency that is not installed, an R constraint written in a form it does not parse, and a `DESCRIPTION` with no floor. Each was found passing silently during review — the same failure the script exists to catch, recurring inside the script itself — so each now fails loudly and names what it could not read, and every guard runs before any exit path.

and on a `DESCRIPTION` reverted to the state #31 reported, it exits 1:

```
Error: DESCRIPTION declares R (>= 3.5) but the hard dependencies require
R (>= 4.4.0). The declared floor is not reachable: raise it, or drop the
dependency that imposes the higher one.
```

**An `ubuntu-latest`, `R 4.4.0` matrix entry.** The package is built, installed and tested on an R at the declared floor for the first time.

**These check different things, and only the first sees what was wrong here.** Installing a package rejects a floor set *above* the running R and accepts any floor *below* it. So no matrix of R versions can detect a floor that is too low, which is the whole of #31. Measured directly on this host: with `DESCRIPTION` reverted to `R (>= 3.5)`, `R CMD INSTALL` and `devtools::check()` both succeed on R 4.6.1. No CI run was made against a reverted `DESCRIPTION`; the inference to the matrix jobs is from that local result and from what installation does, not from a green CI run.

The matrix entry names 4.4.0 literally rather than `oldrel-2`. `oldrel-2` resolves to 4.4.3 today and drifts as R advances, so a base function added in 4.4.1 would pass CI and fail at the declared floor.

**`DESCRIPTION` records no provenance comment.** Writing R Extensions §1.1.1 states the format does not support `#` comments — `read.dcf()` skips them as an implementation detail, not by specification — and any `desc`-based write deletes them silently, including a version bump and `roxygen2` updating `Config/roxygen2/version`. This repository has run both. The script holds the provenance instead, where it is executed rather than trusted.

<details>
<summary>Implementation detail</summary>

### Consequences carried out with the change

`deparse_one()` in `tests/testthat/helper-fixtures.R` existed only because `deparse1()` arrived in R 4.0.0. It is deleted, and its 31 call sites across four test files now call `deparse1()` directly. The two are identical in behaviour: R's `deparse1()` is `paste(deparse(expr, width.cutoff), collapse = collapse)` with `width.cutoff = 500L` and `collapse = " "`, which is what `deparse_one()` was. The suite is unchanged at 616 passing.

`CLAUDE.md`'s note recording the old constraint is rewritten to state the surviving reason for not using bare `deparse()` — its default `width.cutoff` of 60 wraps 8 of 39 formulas, and a wrapped formula deparses to a different string — without the R 3.5 justification. Its `Depends` line is updated with the provenance.

Its `Imports`/`Suggests` list is corrected while adjacent: it still named `gamm4` under `Imports`, which stopped being true when `gamm4` moved to `Suggests`.

### Not done here

`parallel::makePSOCKcluster(setup_strategy = "sequential")` is now available as a mitigation to test against FSSgam_package#14, having been rejected partly on the old floor. That belongs with #14 itself and is not attempted here; it is recorded as a comment on that issue.

`planning/golden-master/capture.R` still defines its own local `deparse_one()`. Left alone: it is a self-contained record of what was run, and its copy still works.

### The script's edge cases

It is the only new code here, so it was run against twelve constructed inputs, three of them requiring scratch packages installed for the purpose. The floor written `R (>=4.4.0)` and `R(>= 4.4.0)` without the usual spaces; `R (>= 4.4)` against `R (>= 4.4.0)`, which must compare equal and do, `package_version()` padding; `R (>= 4.10.0)` against `R (>= 4.9.0)`, which string comparison orders wrongly and `package_version()` does not; version constraints on the `Imports` entries; a hard dependency declared in `Depends` rather than `Imports`, which must not disable the check and does not; a `DESCRIPTION` with no R floor at all; an uninstalled dependency; and package names beginning with R — `Rcpp`, `R6` — which must not be read as the R entry and are not, the pattern being anchored on `R` followed by `(`.

Three scratch dependencies were installed to reach the constraint-parsing paths: one declaring `R (> 4.5.9)`, which is counted as a floor of 4.5.9 and correctly fails a declared 3.5; one declaring `R (<= 9.9.0)`, which stops the script naming the package and the constraint rather than discarding it; and one declaring `Depends: methods`, which reaches the "nothing to check" path legitimately.

### Verification

`devtools::check()`: 0 errors, 0 warnings, 0 notes. `testthat::test_local()`: 616 passing, 0 failing, 7 skipped blocks, unchanged. `tools/check-r-floor.R` was run against 23 constructed cases covering every exit path. The workflow file parses as YAML with the two jobs and the five matrix entries expected. Debian WSL2, R 4.6.1, 2026-09-03.

All six jobs pass at the current head — run 33726514953 on `381a3b3`: `declared R floor is reachable` and `ubuntu-latest (4.4.0)`, alongside the four pre-existing matrix jobs. That confirms two things this host cannot: that `r-lib/actions` resolves a literal `4.4.0`, and that the script runs correctly against a dependency set installed by `setup-r-dependencies` rather than this machine's.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cso3y77sBdk3LyF7yZPfKX
