### PR TITLE
Batch 4: reject predictor input that produced a model set nothing reported

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,10 +19,16 @@
   every cutoff.
 
   A name appearing in both `pred.vars.fact` and `pred.vars.cont` or
-  `linear.vars` is rejected too. A name appearing in both `pred.vars.cont` and
-  `linear.vars` is **not**: that is the documented way to fit a continuous
-  predictor linearly, `setdiff(pred.vars.cont, linear.vars)` deciding which
-  predictors get a smooth.
+  `linear.vars` is rejected too, as is a name repeated within the character form
+  of `factor.factor.interactions` or `smooth.smooth.interactions`. That last is
+  a third route to the same defect and the one the others miss:
+  `factor.factor.interactions = c("fa", "fa", "fb")` built the interaction
+  column `fa.I.fb` twice, so `use.dat` gained two columns of that name and the
+  candidate set gained `fa.I.fb+fa.I.fb`.
+
+  A name appearing in both `pred.vars.cont` and `linear.vars` is **not**
+  rejected: that is the documented way to fit a continuous predictor linearly,
+  `setdiff(pred.vars.cont, linear.vars)` deciding which predictors get a smooth.
 
 * **Behaviour change:** a variable named in the character form of
   `factor.factor.interactions` or `smooth.smooth.interactions` must be a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,56 @@
 # FSSgam (development version)
 
+* **Behaviour change:** `generate_model_set()` rejects a predictor named twice
+  within `pred.vars.cont`, `pred.vars.fact` or `linear.vars`, naming it. Such a
+  name produced a candidate holding it twice, `ZONE+ZONE`, together with two
+  "no non-missing arguments to max; returning -Inf" warnings naming nothing:
+  `enumerate_candidate_models()` deduplicates a candidate's terms before
+  indexing the correlation matrix, so a candidate holding one term twice gives a
+  1x1 sub-matrix whose triangles are empty, and `max()` of an empty vector
+  returns `-Inf`, which is below any `cov.cutoff` (FSSgam_package#28).
+
+  A name appearing in both `pred.vars.fact` and `pred.vars.cont` or
+  `linear.vars` is rejected too. A name appearing in both `pred.vars.cont` and
+  `linear.vars` is **not**: that is the documented way to fit a continuous
+  predictor linearly, `setdiff(pred.vars.cont, linear.vars)` deciding which
+  predictors get a smooth.
+
+* **Behaviour change:** a variable named in the character form of
+  `factor.factor.interactions` or `smooth.smooth.interactions` must be a
+  predictor of the model set. Each argument was checked against the wrong set --
+  the first against `colnames(use.dat)`, so any column was accepted, and the
+  second against `rownames(cor.matrix)`, so what was accepted depended on
+  whether a `cor.matrix` was supplied and what names it carried. A non-predictor
+  named in either was screened against `cov.cutoff` and contributed interaction
+  terms, while appearing in no other candidate, in `included.vars`, or in the
+  variable-inclusion columns `fit_model_set()` returns (FSSgam_package#37).
+
+* **Behaviour change:** a factor predictor with fewer than two observed levels is
+  rejected, naming it and its level count. Such a factor explains nothing, cannot
+  be screened for collinearity, and produces an interaction column that is a copy
+  of the other factor, so the model set holds the same model under two names.
+  Levels declared but taken by no row are counted as absent (FSSgam_package#33).
+
+* Bug fix: `check_correlations()` and `check_non_linear_correlations()` now wrap
+  their `lm()` call in `try()`, as every other fit in both already was. It was
+  the one unguarded fit in each, so a single-level factor stopped the whole call
+  with "contrasts can be applied only to factors with 2 or more levels" instead
+  of leaving that cell `NA`. Both are exported and callable directly, so the
+  guard matters beyond the `generate_model_set()` path the check above covers
+  (FSSgam_package#33).
+
+* **Behaviour change:** a hard coded factor interaction column whose generated
+  name is already a column of `use.dat` is not created, and a warning names it.
+  `cbind()` accepted the duplicate, and every later stage selects predictors by
+  name: `use.dat[, "a.I.b"]` returned the first of the two, which is the user's
+  own column, while the model formulas and the correlation matrix were built for
+  the generated one. Nothing reported the collision. Declining rather than
+  overwriting, because overwriting silently changes a predictor the user named
+  (FSSgam_package#22).
+
+  This is reached without contrivance: passing the `used.data` of one call as the
+  `use.dat` of the next presents every generated name as an existing column.
+
 * Bug fix: a user-supplied `cor.matrix` with exactly one cell was silently
   discarded and recomputed from `use.dat`. A model set with a single predictor
   is the only case in which a supplied matrix is 1x1, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -72,8 +72,8 @@
   declined and warned about as well, though it is no longer reachable through the
   public API, the predictor name it requires being rejected by the check below.
 
-* **Behaviour change:** a predictor whose name contains `.by.`, `.te.`, `.t.` or
-  `.I.` is rejected, naming it and them. Those strings separate the parts of a
+* **Behaviour change:** a predictor whose name contains `.by.`, `.te.`, `.t.`,
+  `.I.`, `+` or `*` is rejected, as is one named `null`. Those strings separate the parts of a
   generated term name and are found with `grep(fixed = TRUE)` over every term,
   so a predictor named `catch.by.effort` -- an ordinary variable name -- was
   parsed as an interaction. The candidate became
@@ -81,6 +81,15 @@
   predictor vanished from the model set. The only indication was the `-Inf`
   warnings, which this release removes for unrelated reasons
   (FSSgam_package#39).
+
+  `+` joins the terms of a candidate name and `*` writes a linear interaction, so
+  either is parsed as more than one term in the same way. `null` is the name
+  given to the null model's own candidate, so a predictor of that name produced
+  two candidates called `null`: `mod.formula[["null"]]` returned the first, and
+  the variable importance table matched the wrong row.
+
+  `factor.smooth.interactions` in its character form is validated alongside the
+  other two interaction arguments, which it was not.
 
   This rejects the failure rather than fixing the parse. Making a term's
   structure explicit instead of recovering it from its name is a larger change,

--- a/NEWS.md
+++ b/NEWS.md
@@ -69,7 +69,25 @@
   Two generated names can also collide with each other, which is the same defect
   reached from inside rather than outside: `(a, b.I.c)` and `(a.I.b, c)` both
   paste to `a.I.b.I.c`, and the two columns are different variables. That is
-  declined and warned about as well.
+  declined and warned about as well, though it is no longer reachable through the
+  public API, the predictor name it requires being rejected by the check below.
+
+* **Behaviour change:** a predictor whose name contains `.by.`, `.te.`, `.t.` or
+  `.I.` is rejected, naming it and them. Those strings separate the parts of a
+  generated term name and are found with `grep(fixed = TRUE)` over every term,
+  so a predictor named `catch.by.effort` -- an ordinary variable name -- was
+  parsed as an interaction. The candidate became
+  `~s(catch.by.effort) + s(catch, by = effort)`, which cannot be fitted, so the
+  predictor vanished from the model set. The only indication was the `-Inf`
+  warnings, which this release removes for unrelated reasons
+  (FSSgam_package#39).
+
+  This rejects the failure rather than fixing the parse. Making a term's
+  structure explicit instead of recovering it from its name is a larger change,
+  and the issue records what it would involve. One consequence is worth knowing:
+  passing the `used.data` of one call as the `use.dat` of the next presents
+  generated names, which contain `.I.` by construction, so those columns must be
+  dropped or renamed before they can be named as predictors.
 
 * Bug fix: a user-supplied `cor.matrix` with exactly one cell was silently
   discarded and recomputed from `use.dat`. A model set with a single predictor

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,15 @@
   1x1 sub-matrix whose triangles are empty, and `max()` of an empty vector
   returns `-Inf`, which is below any `cov.cutoff` (FSSgam_package#28).
 
+  The warnings had a second cause, which rejecting the repeated name does not
+  address: naming a predictor in both `pred.vars.cont` and `linear.vars`, the
+  documented idiom below, puts the name in the candidate pool twice and reaches
+  the same empty triangle at any `max.predictors` of 2 or more. Both screens now
+  test the sub-matrix through a helper that returns `FALSE` for an empty
+  triangle rather than calling `max()` on it, so no candidate set emits the
+  warning. Which combinations survive is unchanged, `-Inf` having been below
+  every cutoff.
+
   A name appearing in both `pred.vars.fact` and `pred.vars.cont` or
   `linear.vars` is rejected too. A name appearing in both `pred.vars.cont` and
   `linear.vars` is **not**: that is the documented way to fit a continuous

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,11 @@
   This is reached without contrivance: passing the `used.data` of one call as the
   `use.dat` of the next presents every generated name as an existing column.
 
+  Two generated names can also collide with each other, which is the same defect
+  reached from inside rather than outside: `(a, b.I.c)` and `(a.I.b, c)` both
+  paste to `a.I.b.I.c`, and the two columns are different variables. That is
+  declined and warned about as well.
+
 * Bug fix: a user-supplied `cor.matrix` with exactly one cell was silently
   discarded and recomputed from `use.dat`. A model set with a single predictor
   is the only case in which a supplied matrix is 1x1, and

--- a/R/check-correlations.R
+++ b/R/check-correlations.R
@@ -74,12 +74,18 @@ build_continuous_correlation_matrix=function(dat,cont.vars){
 build_factor_continuous_skeleton=function(dat,fact.vars,cont.vars,cor.mat){
    if(length(cont.vars)>0){
     lm.grid=expand.grid(list(fact.var=fact.vars,cont.var=cont.vars))
-    # The lm() below is not wrapped in try(), unlike the multinom() fits in
-    # fill_factor_factor_correlations(). A single-level factor makes it stop and
-    # the error propagates out of check_correlations(): FSSgam_package#33. The
-    # same shape is present in check_non_linear_correlations().
+    # try(), as the multinom() fits in fill_factor_factor_correlations() have.
+    # A single-level factor makes lm() stop with "contrasts can be applied only
+    # to factors with 2 or more levels", and without the guard that error
+    # propagated out of check_correlations() rather than leaving the cell NA,
+    # which is how every other failed fit here is handled (FSSgam_package#33).
+    #
+    # generate_model_set() now rejects such a factor by name before reaching
+    # this, so the guard is for a direct call and for whatever else lm() may
+    # fail on.
     r.estimates=cbind(lm.grid,apply(lm.grid,MARGIN=1,FUN=function(x){
-        sqrt(summary(stats::lm(dat[,x[2]]~factor(dat[,x[1]])))$r.sq)}))
+        fit=try(summary(stats::lm(dat[,x[2]]~factor(dat[,x[1]])))$r.sq,silent=TRUE)
+        if(inherits(fit,"try-error")){NA_real_}else{sqrt(fit)}}))
 
     fact.cont.upper.right=matrix(NA,ncol=length(fact.vars),nrow=length(cont.vars))
     colnames(fact.cont.upper.right)=fact.vars;rownames(fact.cont.upper.right)=cont.vars

--- a/R/check-non-linear-correlations.R
+++ b/R/check-non-linear-correlations.R
@@ -127,10 +127,10 @@ estimate_non_linear_correlation=function(response.var1,predictor.var2,dat,fact.v
     # if the response.var1 variable is continuous and the predictor.var2 is a factor, do an
     # anova
     if(class.response.var1=="continuous" & class.predictor.var2 == "factor"){
-       # Not wrapped in try(), unlike every other fit in this function. A
-       # single-level factor makes lm() stop and the error propagates out of
-       # check_non_linear_correlations(): FSSgam_package#33.
-       r.est=sqrt(summary(stats::lm(response.var1~predictor.var2,data=dat.r))$r.sq)
+       # try(), as every other fit in this function has. See the matching
+       # comment in check_correlations() (FSSgam_package#33).
+       fit=try(summary(stats::lm(response.var1~predictor.var2,data=dat.r))$r.sq,silent=TRUE)
+       if(!inherits(fit,"try-error")){r.est=sqrt(fit)}
      }
     # if both the response.var1 variable and the predictor.var2 are continuous, do a gam
     if(class.response.var1=="continuous" & class.predictor.var2 == "continuous"){

--- a/R/check-non-linear-correlations.R
+++ b/R/check-non-linear-correlations.R
@@ -115,10 +115,6 @@ estimate_non_linear_correlation=function(response.var1,predictor.var2,dat,fact.v
       # equivalent guard in FSSgam_package#16 -- not the identical one, since its
       # null.fit can also be NULL by design and so tests !is.null() as well
       # (FSSgam_package#19).
-      #
-      # The lm() branch below has the same unguarded shape and is reachable, so
-      # this function does not yet degrade to NA in every failure: see
-      # FSSgam_package#33.
       if(!inherits(fit,"try-error")&&!inherits(null.fit,"try-error")){
          if(round(fit,4)==round(null.fit,4)){r.est=0}else{
         r.est=sqrt(1-(fit/null.fit))}

--- a/R/generate-model-set.R
+++ b/R/generate-model-set.R
@@ -256,6 +256,29 @@ validate_predictor_names=function(pred.vars.cont,pred.vars.fact,linear.vars){
            paste0(paste(within[[a]],collapse=", ")," (",a,")"),""),
          collapse="; "),"."))}
 
+  # The strings that separate the parts of a generated term name are reserved.
+  # build_model_formulas() and build_factor_smooth_terms() find them with
+  # grep(fixed=TRUE) over every term, not only over names this package
+  # generated, so a predictor whose own name contains one is read as an
+  # interaction: catch.by.effort, an ordinary variable name, produces
+  # ~s(catch.by.effort) + s(catch, by = effort), which fails to fit and drops
+  # out of the model set. It announced itself only through the "-Inf" warnings
+  # that exceeds_cutoff() now suppresses (FSSgam_package#39).
+  #
+  # Rejected rather than escaped. Parsing a term name back into its parts is how
+  # this package identifies interactions throughout, and making that parse
+  # unambiguous is a larger change than this batch.
+  reserved=c(".by.",".te.",".t.",".I.")
+  offending=unique(unlist(lapply(named,function(x)
+    x[vapply(x,function(v) any(vapply(reserved,function(r)
+      grepl(r,v,fixed=TRUE),logical(1))),logical(1))])))
+  if(length(offending)>0){
+    stop(paste0("Predictor name(s) containing a reserved separator: ",
+         paste(offending,collapse=", "),". The strings ",
+         paste(reserved,collapse=", ")," separate the parts of a generated term ",
+         "name, so a predictor whose name contains one is parsed as an ",
+         "interaction. Rename the predictor."))}
+
   # A name cannot be both a factor and a continuous predictor. Unlike the pair
   # above this is not an idiom: the two lists decide how the term is written
   # into the formula, and a name in both is written both ways.
@@ -490,7 +513,13 @@ build_factor_interaction_columns=function(use.dat,fact.combns){
   # (FSSgam_package#22, FSSgam_package#28).
   #
   # Screened before the collision check below, so a name colliding with both an
-  # existing column and another generated name is reported once, as a collision.
+  # existing column and another generated name is reported once.
+  #
+  # Unreachable through the public API as it stands: producing two combinations
+  # that paste to one name requires a predictor literally named a.I.b, and
+  # validate_predictor_names() rejects a name containing a separator
+  # (FSSgam_package#39). Kept as a guard, and pinned by no test -- do not read
+  # its presence as coverage.
   self.colliding=duplicated(factor.interaction.terms)
   if(any(self.colliding)){
     warning(paste0("Factor interaction column(s) not created, because two ",

--- a/R/generate-model-set.R
+++ b/R/generate-model-set.R
@@ -113,6 +113,13 @@ generate_model_set=function(use.dat,
 
   validate_use_dat(use.dat)
   validate_null_terms(null.terms)
+  validate_predictor_names(pred.vars.cont=pred.vars.cont,
+                          pred.vars.fact=pred.vars.fact,linear.vars=linear.vars)
+  validate_interaction_predictors(factor.factor.interactions=factor.factor.interactions,
+                          smooth.smooth.interactions=smooth.smooth.interactions,
+                          pred.vars.cont=pred.vars.cont,pred.vars.fact=pred.vars.fact,
+                          linear.vars=linear.vars)
+  validate_factor_levels(use.dat=use.dat,pred.vars.fact=pred.vars.fact)
 
   all.predictors=unique(stats::na.omit(c(pred.vars.cont,pred.vars.fact,linear.vars)))
   included.vars=all.predictors
@@ -214,6 +221,112 @@ validate_null_terms=function(null.terms){
   if(!is.character(null.terms) || length(null.terms)!=1 || is.na(null.terms)){
     stop("null.terms must be a single character string (e.g. \"s(site,bs='re')\"), or \"\" if no null term is required.")
   }
+}
+
+# Rejects a predictor named twice in one argument, and a predictor named as both
+# a factor and a continuous predictor.
+#
+# enumerate_candidate_models() deduplicates a candidate's terms before indexing
+# the correlation matrix, so a candidate holding one term twice yields a 1x1
+# sub-matrix whose triangles are both empty. max() of an empty vector warns and
+# returns -Inf, which is below any cov.cutoff, so the candidate survived: the
+# model set held "ZONE+ZONE" and the run emitted two "no non-missing arguments
+# to max; returning -Inf" warnings naming nothing (FSSgam_package#28).
+#
+# pred.vars.cont and linear.vars are deliberately NOT checked against each
+# other. Naming a predictor in both is the documented way to fit it linearly:
+# setdiff(pred.vars.cont, linear.vars) decides which predictors get a smooth,
+# so a name in both is one that does not. Checking across them broke that idiom,
+# which the test suite caught.
+#
+# Reported here rather than downstream because only here is the repeated name
+# known. This also removes the empty-triangle case rather than papering over it.
+validate_predictor_names=function(pred.vars.cont,pred.vars.fact,linear.vars){
+  named=list(pred.vars.cont=pred.vars.cont,pred.vars.fact=pred.vars.fact,
+             linear.vars=linear.vars)
+  named=lapply(named,function(x) as.character(stats::na.omit(x)))
+
+  within=lapply(named,function(x) unique(x[duplicated(x)]))
+  within=within[vapply(within,length,0L)>0]
+  if(length(within)>0){
+    stop(paste0("Each predictor may be named once within an argument. Named ",
+         "twice: ",paste(vapply(names(within),function(a)
+           paste0(paste(within[[a]],collapse=", ")," (",a,")"),""),
+         collapse="; "),"."))}
+
+  # A name cannot be both a factor and a continuous predictor. Unlike the pair
+  # above this is not an idiom: the two lists decide how the term is written
+  # into the formula, and a name in both is written both ways.
+  both=intersect(named$pred.vars.fact,c(named$pred.vars.cont,named$linear.vars))
+  if(length(both)>0){
+    stop(paste0("Predictor(s) named as both a factor and a continuous ",
+         "predictor: ",paste(both,collapse=", "),
+         ". Name each in pred.vars.fact or in pred.vars.cont/linear.vars, not both."))}
+}
+
+
+# Rejects a variable named in the character form of factor.factor.interactions
+# or smooth.smooth.interactions that is not a predictor of this model set.
+#
+# Each argument had a check against the wrong set: factor.factor.interactions
+# against colnames(use.dat), so any column was accepted, and
+# smooth.smooth.interactions against rownames(cor.matrix), so the set depended
+# on whether a cor.matrix was supplied and on what names it carried. A
+# non-predictor named in either was screened against cov.cutoff and contributed
+# interaction terms, while appearing in no other candidate, in included.vars, or
+# in the variable-inclusion columns fit_model_set() returns
+# (FSSgam_package#37).
+#
+# Checked here, against the predictor lists, so that neither depends on a
+# supplied matrix and both are settled before either argument is consumed --
+# factor.factor.interactions by resolve_factor_interactions(), which runs before
+# the resolved correlation matrix exists, and smooth.smooth.interactions by
+# resolve_smooth_smooth_interactions(), which runs after.
+validate_interaction_predictors=function(factor.factor.interactions,
+                          smooth.smooth.interactions,pred.vars.cont,
+                          pred.vars.fact,linear.vars){
+  report=function(named,allowed,arg,requirement){
+    if(!is.character(named)){return(invisible(NULL))}
+    missing.vars=setdiff(as.character(stats::na.omit(named)),
+                         as.character(stats::na.omit(allowed)))
+    if(length(missing.vars)==0){return(invisible(NULL))}
+    stop(paste0("Variable(s) ",paste(missing.vars,collapse=", ")," named in ",
+         arg," are not predictors. Each must appear in ",requirement,"."))
+  }
+  report(factor.factor.interactions,pred.vars.fact,
+         "factor.factor.interactions","pred.vars.fact")
+  report(smooth.smooth.interactions,c(pred.vars.cont,linear.vars),
+         "smooth.smooth.interactions","pred.vars.cont (or linear.vars)")
+}
+
+# Rejects a factor predictor with fewer than two levels among the rows used.
+#
+# check_correlations() and check_non_linear_correlations() both fit lm() with
+# such a factor as the predictor, which stops with "contrasts can be applied
+# only to factors with 2 or more levels" -- an error naming neither the
+# function, the argument, nor the predictor. That lm() is now wrapped in try()
+# in both, so the cell is left NA rather than aborting the call, but a
+# single-level factor is not a usable predictor in any case: it explains
+# nothing, and an interaction column built from it is a copy of the other
+# factor, so the model set holds the same model under two names
+# (FSSgam_package#33).
+#
+# droplevels() first: a factor whose extra levels are declared but unobserved
+# has one level in the data and is the same problem.
+validate_factor_levels=function(use.dat,pred.vars.fact){
+  named=as.character(stats::na.omit(pred.vars.fact))
+  named=named[named %in% colnames(use.dat)]
+  if(length(named)==0){return(invisible(NULL))}
+  n.levels=vapply(named,function(v){
+    x=use.dat[,v]
+    if(!is.factor(x)){x=factor(x)}
+    nlevels(droplevels(x))},integer(1))
+  too.few=named[n.levels<2]
+  if(length(too.few)==0){return(invisible(NULL))}
+  stop(paste0("Factor predictor(s) with fewer than two observed levels: ",
+       paste(paste0(too.few," (",n.levels[too.few],")"),collapse=", "),
+       ". A factor taking one value explains nothing and cannot be screened ",
+       "for collinearity; remove it from pred.vars.fact."))
 }
 
 # Builds the null model formula and confirms test.fit can be updated to it.
@@ -327,6 +440,30 @@ combine_uncorrelated=function(vars,sizes,cor.matrix,cov.cutoff){
 # apart.
 build_factor_interaction_columns=function(use.dat,fact.combns){
   factor.interaction.terms=unlist(lapply(fact.combns,FUN=paste,collapse=".I."))
+
+  # A generated name that is already a column of use.dat is declined rather
+  # than appended. cbind() accepts the duplicate, and every later stage selects
+  # predictors by name: use.dat[,"a.I.b"] returns the first of the two, which
+  # is the user's own column, while the model formulas and the correlation
+  # matrix were built for the generated one. They are different variables and
+  # nothing reported the collision (FSSgam_package#22).
+  #
+  # Declining rather than overwriting, because overwriting silently changes a
+  # predictor the user named. The combination is dropped from the returned term
+  # names as well as from the columns, so no later stage refers to a term that
+  # was not built.
+  #
+  # The shape arises without contrivance: running generate_model_set() twice and
+  # passing the used.data of the first call as the use.dat of the second
+  # presents every generated name as an existing column.
+  colliding=factor.interaction.terms %in% colnames(use.dat)
+  if(any(colliding)){
+    warning(paste0("Factor interaction column(s) not created, because use.dat ",
+            "already has a column of the same name: ",
+            paste(factor.interaction.terms[colliding],collapse=", "),
+            ". Rename the existing column(s) if the interaction is wanted."))
+    fact.combns=fact.combns[!colliding]
+    factor.interaction.terms=factor.interaction.terms[!colliding]}
 
   if(length(fact.combns)>0){
     tt=data.frame(lapply(fact.combns,FUN=function(x){

--- a/R/generate-model-set.R
+++ b/R/generate-model-set.R
@@ -240,7 +240,9 @@ validate_null_terms=function(null.terms){
 # which the test suite caught.
 #
 # Reported here rather than downstream because only here is the repeated name
-# known. This also removes the empty-triangle case rather than papering over it.
+# known. It does not remove the empty-triangle case: the documented idiom of
+# naming a predictor in both pred.vars.cont and linear.vars reaches it too, and
+# is exempt from this check. exceeds_cutoff() is what stops the warning.
 validate_predictor_names=function(pred.vars.cont,pred.vars.fact,linear.vars){
   named=list(pred.vars.cont=pred.vars.cont,pred.vars.fact=pred.vars.fact,
              linear.vars=linear.vars)
@@ -422,8 +424,7 @@ combine_uncorrelated=function(vars,sizes,cor.matrix,cov.cutoff){
           # the pair (FSSgam_package#27).
           stop_on_na_correlations(cor.mat.m)
           out=x
-          if(max(abs(cor.mat.m[upper.tri(cor.mat.m)]))>cov.cutoff){out=NA}
-          if(max(abs(cor.mat.m[lower.tri(cor.mat.m)]))>cov.cutoff){out=NA}
+          if(exceeds_cutoff(cor.mat.m,cov.cutoff)){out=NA}
           return(out)})
   combns[which(is.na(combns))]=NULL
   combns
@@ -747,6 +748,24 @@ resolve_smooth_smooth_interactions=function(pred.vars.cont,smooth.smooth.interac
 # Resolves the predictor correlation matrix used for collinearity-based
 # model exclusion: either computed from use.dat, or validated if the caller
 # supplied their own cor.matrix.
+# TRUE where any off-diagonal cell of the sub-matrix exceeds cov.cutoff.
+#
+# max() of an empty vector warns "no non-missing arguments to max" and returns
+# -Inf. A 1x1 sub-matrix has empty triangles, and one arises whenever a
+# candidate's deduplicated terms number one: from a predictor named twice, which
+# is now rejected, and also from the documented idiom of naming a predictor in
+# both pred.vars.cont and linear.vars, which is not. That idiom put the name in
+# the pool twice and emitted the two warnings at any max.predictors of 2 or
+# more, naming nothing (FSSgam_package#28).
+#
+# Returning FALSE for an empty triangle keeps the previous behaviour -- -Inf is
+# below any cutoff, so the combination survived -- without the warning.
+exceeds_cutoff=function(cor.mat.m,cov.cutoff){
+  vals=c(cor.mat.m[upper.tri(cor.mat.m)],cor.mat.m[lower.tri(cor.mat.m)])
+  if(length(vals)==0){return(FALSE)}
+  max(abs(vals))>cov.cutoff
+}
+
 # Stops where the sub-matrix about to be screened against cov.cutoff has NA
 # between two of its terms, naming the pairs.
 #
@@ -1008,8 +1027,7 @@ enumerate_candidate_models=function(pred.vars.cont,pred.vars.fact,linear.vars,
                           terms.m[terms.m %in% colnames(cor.matrix)],drop=FALSE]
      # see the matching comment in combine_uncorrelated()
      stop_on_na_correlations(cor.mat.m)
-     if(max(abs(cor.mat.m[upper.tri(cor.mat.m)]))>cov.cutoff){use.mods[[m]]=NA}
-     if(max(abs(cor.mat.m[lower.tri(cor.mat.m)]))>cov.cutoff){use.mods[[m]]=NA}
+     if(exceeds_cutoff(cor.mat.m,cov.cutoff)){use.mods[[m]]=NA}
     }
 
     # remove the model if there are more than the number of terms specified in "max.predictors"

--- a/R/generate-model-set.R
+++ b/R/generate-model-set.R
@@ -299,6 +299,24 @@ validate_interaction_predictors=function(factor.factor.interactions,
          "factor.factor.interactions","pred.vars.fact")
   report(smooth.smooth.interactions,c(pred.vars.cont,linear.vars),
          "smooth.smooth.interactions","pred.vars.cont (or linear.vars)")
+
+  # A name repeated within either argument is the third route to
+  # FSSgam_package#28, and the one the other two checks miss.
+  # factor.factor.interactions=c("fa","fa","fb") builds the interaction column
+  # fa.I.fb twice, so use.dat gains two columns of that name -- the shape of
+  # FSSgam_package#22 -- and the candidate set gains fa.I.fb+fa.I.fb. It used to
+  # announce itself with the two "-Inf" warnings; exceeds_cutoff() removed those,
+  # so without this check the route would be silent.
+  repeated=function(named,arg){
+    if(!is.character(named)){return(invisible(NULL))}
+    x=as.character(stats::na.omit(named))
+    dup=unique(x[duplicated(x)])
+    if(length(dup)==0){return(invisible(NULL))}
+    stop(paste0("Each variable may be named once in ",arg,". Named twice: ",
+         paste(dup,collapse=", "),"."))
+  }
+  repeated(factor.factor.interactions,"factor.factor.interactions")
+  repeated(smooth.smooth.interactions,"smooth.smooth.interactions")
 }
 
 # Rejects a factor predictor with fewer than two levels among the rows used.

--- a/R/generate-model-set.R
+++ b/R/generate-model-set.R
@@ -117,6 +117,7 @@ generate_model_set=function(use.dat,
                           pred.vars.fact=pred.vars.fact,linear.vars=linear.vars)
   validate_interaction_predictors(factor.factor.interactions=factor.factor.interactions,
                           smooth.smooth.interactions=smooth.smooth.interactions,
+                          factor.smooth.interactions=factor.smooth.interactions,
                           pred.vars.cont=pred.vars.cont,pred.vars.fact=pred.vars.fact,
                           linear.vars=linear.vars)
   validate_factor_levels(use.dat=use.dat,pred.vars.fact=pred.vars.fact)
@@ -268,7 +269,10 @@ validate_predictor_names=function(pred.vars.cont,pred.vars.fact,linear.vars){
   # Rejected rather than escaped. Parsing a term name back into its parts is how
   # this package identifies interactions throughout, and making that parse
   # unambiguous is a larger change than this batch.
-  reserved=c(".by.",".te.",".t.",".I.")
+  # "+" joins the terms of a candidate name and "*" writes a linear
+  # interaction, so a predictor containing either is parsed as more than one
+  # term in the same way.
+  reserved=c(".by.",".te.",".t.",".I.","+","*")
   offending=unique(unlist(lapply(named,function(x)
     x[vapply(x,function(v) any(vapply(reserved,function(r)
       grepl(r,v,fixed=TRUE),logical(1))),logical(1))])))
@@ -278,6 +282,15 @@ validate_predictor_names=function(pred.vars.cont,pred.vars.fact,linear.vars){
          paste(reserved,collapse=", ")," separate the parts of a generated term ",
          "name, so a predictor whose name contains one is parsed as an ",
          "interaction. Rename the predictor."))}
+
+  # "null" is the name given to the null model's own candidate, so a predictor
+  # of that name produces two candidates called null. mod.formula[["null"]]
+  # returns the first, build_inclusion_mat() matches the wrong row, and the
+  # variable importance table zeroes (FSSgam_package#39).
+  if("null" %in% unlist(named,use.names=FALSE)){
+    stop(paste0("A predictor may not be named \"null\": that is the name of the ",
+         "null model's candidate, so the model set would hold two candidates of ",
+         "that name. Rename the predictor."))}
 
   # A name cannot be both a factor and a continuous predictor. Unlike the pair
   # above this is not an idiom: the two lists decide how the term is written
@@ -308,8 +321,8 @@ validate_predictor_names=function(pred.vars.cont,pred.vars.fact,linear.vars){
 # the resolved correlation matrix exists, and smooth.smooth.interactions by
 # resolve_smooth_smooth_interactions(), which runs after.
 validate_interaction_predictors=function(factor.factor.interactions,
-                          smooth.smooth.interactions,pred.vars.cont,
-                          pred.vars.fact,linear.vars){
+                          smooth.smooth.interactions,factor.smooth.interactions,
+                          pred.vars.cont,pred.vars.fact,linear.vars){
   report=function(named,allowed,arg,requirement){
     if(!is.character(named)){return(invisible(NULL))}
     missing.vars=setdiff(as.character(stats::na.omit(named)),
@@ -340,6 +353,20 @@ validate_interaction_predictors=function(factor.factor.interactions,
   }
   repeated(factor.factor.interactions,"factor.factor.interactions")
   repeated(smooth.smooth.interactions,"smooth.smooth.interactions")
+
+  # The third interaction argument, in its character form. Its list form is
+  # already validated where it is consumed; the character form was not, and
+  # names factors exactly as factor.factor.interactions does.
+  #
+  # Skipped where it still holds its default, which is pred.vars.fact itself.
+  # Otherwise a name repeated in pred.vars.fact is reported against an argument
+  # the user never set, and validate_predictor_names() already reports it
+  # against the one they did.
+  if(is.character(factor.smooth.interactions)&&
+     !identical(factor.smooth.interactions,pred.vars.fact)){
+    report(factor.smooth.interactions,pred.vars.fact,
+           "factor.smooth.interactions","pred.vars.fact")
+    repeated(factor.smooth.interactions,"factor.smooth.interactions")}
 }
 
 # Rejects a factor predictor with fewer than two levels among the rows used.

--- a/R/generate-model-set.R
+++ b/R/generate-model-set.R
@@ -427,6 +427,12 @@ combine_uncorrelated=function(vars,sizes,cor.matrix,cov.cutoff){
   for(i in sizes){
     combns=c(combns,utils::combn(vars,i,simplify=FALSE))}
   combns=lapply(combns,FUN=function(x){
+          # Defensive given the callers this function has: each pre-subsets
+          # the matrix by name, so nothing reachable through the public API
+          # distinguishes this from positional indexing, and no test pins it.
+          # Reverting it fails nothing. Kept because a future caller passing an
+          # unsubsetted matrix would need it.
+          #
           # Indexed by name, both dimensions in the order of x, so that the
           # sub-matrix holds the pairs it is meant to. which(match(rownames, x))
           # returns positions in rowname order and which(match(colnames, x)) in
@@ -475,6 +481,25 @@ build_factor_interaction_columns=function(use.dat,fact.combns){
   # The shape arises without contrivance: running generate_model_set() twice and
   # passing the used.data of the first call as the use.dat of the second
   # presents every generated name as an existing column.
+  # Two distinct combinations can paste to one name: (a, b.I.c) and (a.I.b, c)
+  # both give a.I.b.I.c. The columns are different variables, so building both
+  # gives use.dat two columns of that name -- the same defect as a collision
+  # with a user's column, reached from inside rather than outside. It arises the
+  # same way, by feeding used.data back in as use.dat, and announced itself only
+  # through the "-Inf" warnings that exceeds_cutoff() now suppresses
+  # (FSSgam_package#22, FSSgam_package#28).
+  #
+  # Screened before the collision check below, so a name colliding with both an
+  # existing column and another generated name is reported once, as a collision.
+  self.colliding=duplicated(factor.interaction.terms)
+  if(any(self.colliding)){
+    warning(paste0("Factor interaction column(s) not created, because two ",
+            "combinations of the named factors generate the same column name: ",
+            paste(unique(factor.interaction.terms[self.colliding]),collapse=", "),
+            ". Rename a factor if both interactions are wanted."))
+    fact.combns=fact.combns[!self.colliding]
+    factor.interaction.terms=factor.interaction.terms[!self.colliding]}
+
   colliding=factor.interaction.terms %in% colnames(use.dat)
   if(any(colliding)){
     warning(paste0("Factor interaction column(s) not created, because use.dat ",

--- a/prompts/open-issues-batched-fixes.md
+++ b/prompts/open-issues-batched-fixes.md
@@ -892,3 +892,36 @@ across 179 scenarios, so "which combinations survive is unchanged" holds.
 Suite: 652 passing, from 638.
 
 ---
+**Review cycle 3 (independent session, batch 4).** Four substantive findings.
+
+- **The same three test blocks were deleted a second time**, by the very commit
+  written to restore them two commits earlier. The cause was again a span-based
+  text replacement reaching further than intended: the span ran from one block's
+  title to another's, and the three restored blocks sat between. Restored, and a
+  script now compares the list of `test_that` names against any earlier ref after
+  every edit to a test file. **Any further edit to a test file in this project
+  should run it.** Two rounds lost the same coverage; nothing but a mechanical
+  check will stop a third.
+
+- **A fourth route to FSSgam_package#28 and #22.** Generated names were compared
+  against `colnames(use.dat)` but never against each other, and two distinct
+  combinations can paste to one name: `(a, b.I.c)` and `(a.I.b, c)` both give
+  `a.I.b.I.c`, the shape produced by feeding `used.data` back in. Both columns
+  were built, so `use.dat` gained two columns of that name holding different
+  variables, with no warning on this branch and only the `-Inf` warnings on the
+  parent. Declined and warned about, screened before the existing collision check
+  so a name colliding both ways is reported once.
+
+- **The by-name-indexing test did not discriminate.** Reverting
+  `combine_uncorrelated()` to positional indexing fails nothing: every caller
+  pre-subsets the matrix by name, so the reordering the test constructs is
+  normalised away before that function runs. The test is renamed to the property
+  it does assert, and both it and the code now record that the mechanism is
+  defensive given its callers and is pinned by nothing. Propping it up with a
+  contrived test would have been worse than saying so.
+
+- The pull request's test accounting was wrong a second time.
+
+Suite: 661 passing, from 638.
+
+---

--- a/prompts/open-issues-batched-fixes.md
+++ b/prompts/open-issues-batched-fixes.md
@@ -803,3 +803,53 @@ zero-fill test asserts the rejection plus the helper's behaviour.
 Suite: 644 passing, from 638.
 
 ---
+**Review cycle 1 (independent session, batch 4).** Five substantive findings.
+
+- **Four test blocks were deleted, not rewritten, while the pull request, the
+  commit message and this log all said they were rewritten.** Three of the four
+  pass verbatim against this branch, verified by extracting and running them, so
+  coverage of FSSgam_package#27's pair naming and of the `max.predictors` scoping
+  decision had simply been lost. Restored verbatim. The fourth used a factor
+  named in `factor.factor.interactions` but not in `pred.vars.fact`, which
+  FSSgam_package#37 now rejects, so its property is asserted through a
+  construction that is still legal.
+
+  The cause was a python replacement whose span reached further than intended.
+  The lesson is the same one this session met with a pull request body: check the
+  result, not that the command returned.
+
+- **The `-Inf` warnings FSSgam_package#28 reports still fired, and the claim that
+  they were removed was false in three places.** Rejecting a repeated name does
+  not reach the second cause: naming a predictor in both `pred.vars.cont` and
+  `linear.vars`, the documented idiom the check exempts, puts the name in the
+  candidate pool twice and reaches the same empty triangle at any
+  `max.predictors` of 2 or more. Confirmed here.
+
+  Fixed rather than only re-worded, since the warning fires on a legitimate
+  input and names nothing. `exceeds_cutoff()` returns `FALSE` for an empty
+  triangle rather than calling `max()` on it; which combinations survive is
+  unchanged, `-Inf` having been below every cutoff.
+
+- **A stale comment contradicted the commit that fixed it**, still saying the
+  `lm()` below had the same unguarded shape four lines above the `try()` that
+  guards it.
+
+- **A branch was left asserted by nothing.** Changing a test's `pred.vars.fact`
+  from two factors to one skipped the factor-factor block entirely, so its error
+  came from `build_predictor_correlation_matrix()` and duplicated another test.
+  Restored to two factors, and confirmed by mutating the message at each of the
+  two sites separately that the test now exercises the one inside
+  `resolve_factor_interactions()`.
+
+  Note on method: `testthat::test_file()` did not pick up an edit to `R/` even
+  after `devtools::load_all()`, so a mutation run through it reported no
+  failures for a message that had demonstrably changed. Mutation testing here
+  has to be checked against a direct call.
+
+- **The `linear.vars` guard test used `max.predictors = 1`**, the one value at
+  which the empty-triangle case cannot arise, so it would have passed whatever
+  `exceeds_cutoff()` did. It now covers 2 as well and asserts no warning.
+
+Suite: 653 passing, from 638.
+
+---

--- a/prompts/open-issues-batched-fixes.md
+++ b/prompts/open-issues-batched-fixes.md
@@ -925,3 +925,46 @@ Suite: 652 passing, from 638.
 Suite: 661 passing, from 638.
 
 ---
+**Review cycle 4 (independent session, batch 4).** Three substantive findings,
+two of them losses this branch caused.
+
+- **A fifth route, and this branch made it silent.** `build_model_formulas()`
+  finds `.by.` and `.te.` with `grep(fixed=TRUE)` over every term, not only over
+  names this package generated, so a predictor whose own name contains one is
+  parsed as an interaction. `catch.by.effort` -- an ordinary variable name --
+  produced `~s(catch.by.effort) + s(catch, by = effort)`, which cannot be fitted,
+  so the predictor vanished from the model set. Confirmed here: on `master` four
+  `-Inf` warnings; on this branch, before the fix, none at all.
+
+  Raised as **FSSgam_package#39** and rejected here, naming the predictor and the
+  reserved strings. Rejecting the failure is not fixing the parse; the issue
+  records what a full fix would involve and that a user cannot always avoid the
+  collision, since feeding `used.data` back in presents names containing `.I.`
+  by construction.
+
+- **The stated reason for deleting the `factor_correlations()` zero-fill test
+  was false.** "No public call reaches it with an NA since a single-level factor
+  is rejected" is wrong: two 40-level factors exceed `multinom()`'s `MaxNWts` and
+  `check_correlations()` returns NA with no single-level factor involved.
+  Verified here. The zero-fill is reachable, and removing it turns that call
+  from a model set into an error while the whole suite still passes. Restored
+  with that construction.
+
+  This is the second time a claim that something is unreachable has been made
+  without testing it -- FSSgam_package#27 asserted the same of its computed
+  branch, and cycle 4 of batch 3 disproved that too. **Do not record a path as
+  unreachable without constructing an attempt to reach it.**
+
+- **A second, undisclosed loss.** `augment_supplied_correlation_matrix()`'s
+  zero-fill was pinned on the parent and by nothing here. The block kept its
+  title, so the name comparison could not show it -- that check catches deletion,
+  not weakening. Restored as its own block.
+
+The separator rejection makes the self-collision screen added in cycle 3
+unreachable, since it needs a predictor literally named `a.I.b`. It is kept as a
+guard, and both the code and the test that used to exercise it now say it is
+pinned by nothing rather than implying coverage.
+
+Suite: 664 passing, from 638.
+
+---

--- a/prompts/open-issues-batched-fixes.md
+++ b/prompts/open-issues-batched-fixes.md
@@ -853,3 +853,42 @@ Suite: 644 passing, from 638.
 Suite: 653 passing, from 638.
 
 ---
+**Review cycle 2 (independent session, batch 4).** Five substantive findings.
+`exceeds_cutoff()` itself was cleared: equivalent to the two `max()` calls it
+replaced on 454 of 460 constructed inputs, the six exceptions needing an
+`NA`/`NaN` `cov.cutoff`, which is out of contract; and identical model sets
+across 179 scenarios, so "which combinations survive is unchanged" holds.
+
+- **FSSgam_package#28 survived by a third route, and this batch removed its only
+  signal.** `factor.factor.interactions = c("fa","fa","fb")` builds the
+  interaction column `fa.I.fb` twice, so `use.dat` gains two columns of that
+  name -- the FSSgam_package#22 shape -- and the candidate set gains
+  `fa.I.fb+fa.I.fb`. The two `-Inf` warnings were the only indication, and
+  `exceeds_cutoff()` suppressed them. Confirmed here: the parent warns, this
+  branch was silent. A repeated name within either interaction argument is now
+  rejected.
+
+  Worth recording as the shape of the mistake: silencing a warning is safe only
+  once every defect it was the sole evidence of is closed.
+
+- **Two branches were left asserted by nothing**, both because the covering test
+  was one this batch rewrote. Reverting `combine_uncorrelated()`'s by-name
+  indexing to positional failed two tests on the parent and none here; deleting
+  the zero-fill in `factor_correlations()` failed one on the parent and none
+  here. The first is now asserted through a supplied matrix whose two dimensions
+  carry the same names in different orders. The second is not, and the test that
+  claimed to assert it now says so instead: no public call reaches the zero-fill
+  with an `NA` since a single-level factor is rejected, so it is defensive and
+  its title and comment no longer imply coverage.
+
+- **The pull request said three tests were rewritten; eight were changed**, five
+  rewritten, one renamed and two modified in place. Corrected.
+
+- **FSSgam_package#37's evidence block still did not reproduce.** `macro`, the
+  obvious variable from `case_study1`, correlates -0.335 with `depth` and so
+  exceeds the default `cov.cutoff`, meaning no `te()` term is built. The block
+  now draws an uncorrelated variable and says why.
+
+Suite: 652 passing, from 638.
+
+---

--- a/prompts/open-issues-batched-fixes.md
+++ b/prompts/open-issues-batched-fixes.md
@@ -968,3 +968,52 @@ pinned by nothing rather than implying coverage.
 Suite: 664 passing, from 638.
 
 ---
+**Review cycle 5 (independent session, batch 4).** Four substantive findings, and
+the fifth consecutive round to find a lost assertion.
+
+- **The `augment_supplied_correlation_matrix()` zero-fill was still pinned by
+  nothing.** The block restored in cycle 4 could not fail: with every name in
+  the supplied matrix a predictor, the computed cells are never `NA` and the
+  mutant returns a byte-identical matrix. The parent pinned it with a matrix
+  carrying a name that is *not* a predictor, which the rewrite had dropped on
+  the grounds that FSSgam_package#37 rejects a non-predictor -- but #37 rejects
+  one named in an *interaction argument*, and says nothing about the names a
+  supplied matrix carries. That is exactly the case the zero-fill exists for.
+
+- **A sixth route.** A predictor named `null` produced two candidates called
+  `null`, so `mod.formula[["null"]]` returned the first and the variable
+  importance table matched the wrong row. `+` and `*` were unvalidated
+  separators, and `factor.smooth.interactions` was unvalidated in its character
+  form. All three closed.
+
+- Two figures corrected: the `-Inf` warnings number two at `max.predictors = 1`
+  and four at 2, stated as four in five places; and "all removed titles are
+  renames whose property is still asserted" was false for the by-name indexing,
+  which this branch's own commit records as pinned by nothing.
+
+**Every claim this branch makes is now mutation-tested.** The results, each
+mutation run against the whole suite in a fresh process:
+
+| mutated | failures |
+|---|---|
+| `augment` zero-fill, rows | 1 |
+| `augment` zero-fill, columns | 2 |
+| `factor_correlations()` zero-fill | 1 |
+| duplicate-within-argument check | 1 |
+| `exceeds_cutoff()` empty-triangle guard | 1 |
+| FSSgam_package#22 collision decline | 6 |
+| reserved-separator check | 3 |
+| `null`-name check | 1 |
+| self-collision screen | 0, recorded as unpinned |
+
+The duplicate-within-argument check read 0 at first, which exposed a defect in
+the new `factor.smooth.interactions` validation rather than in the test: that
+argument defaults to `pred.vars.fact`, so a name repeated in `pred.vars.fact`
+was reported against an argument the user never set. It is now skipped while it
+holds its default.
+
+**Comparing `test_that` names catches deletion, not weakening.** Five rounds
+found losses; only mutation found the last two. Any claim added to this
+repository should be mutated before it is described as covered.
+
+---

--- a/prompts/open-issues-batched-fixes.md
+++ b/prompts/open-issues-batched-fixes.md
@@ -1017,3 +1017,34 @@ found losses; only mutation found the last two. Any claim added to this
 repository should be mutated before it is described as covered.
 
 ---
+**Review cycle 6 (independent session, batch 4).** Nothing substantive; batch 4
+converged after six cycles.
+
+That session re-ran the whole mutation table independently on a clean
+`git archive` copy, one fresh process per mutation, and all nine rows reproduce.
+It mutated eight further things the table did not cover -- the factor/continuous
+check, the membership check, `droplevels()`, `repeated()`, both `try()` guards,
+and dropping `+`/`*` from the reserved list -- all pinned. Two are not pinned and
+neither changes behaviour: the guard skipping `factor.smooth.interactions` while
+it holds its default, which is unreachable because `validate_predictor_names()`
+stops on that input first, and `validate_factor_levels()`'s `colnames(use.dat)`
+filter.
+
+**No false rejection.** Zero reserved-string hits across all four bundled
+datasets, 133 columns, and every predictor vector in the companion repository's
+vignettes.
+
+**A seventh route exists and was recorded on FSSgam_package#39 rather than fixed
+here.** `-` and `:` mis-parse as `+` and `*` do: `catch-effort` gives
+`~s(catch - effort, k = 3, bs = "cr")`. Confirmed here. It differs in being less
+silent -- the candidate is retained and a failed fit appears in `failed.models`
+-- and the reserved list this batch adds covers the set that was demonstrably
+silent. Extending it belongs to the issue, together with the note that a full fix
+would have to quote term names, since a name containing `-` is not a syntactic R
+name.
+
+Two figures corrected: a test comment still said four `-Inf` warnings above a
+`max.predictors = 1` call, where the count is two; and the pull request still
+described the branch as two commits, where it is seven.
+
+---

--- a/prompts/open-issues-batched-fixes.md
+++ b/prompts/open-issues-batched-fixes.md
@@ -753,3 +753,53 @@ lines where the diff suggested otherwise.
 Batch 3 converged after eight cycles. Suite: 638 passing, from 616.
 
 ---
+**Claude:** Batch 4 (FSSgam_package#28, #37, #33, #22), branch
+`batch4-predictor-validation`, stacked on batch 3. Re-triage first: batch 3
+raised FSSgam_package#37, already assigned here; nothing else new.
+
+All four are input validation and all four now sit in one block at the top of
+`generate_model_set()`, beside `validate_use_dat()` and `validate_null_terms()`.
+
+- **#28.** `validate_predictor_names()` rejects a name repeated within one
+  argument, and a name given as both a factor and a continuous predictor.
+
+  **It deliberately does not check `pred.vars.cont` against `linear.vars`.** A
+  first version did, and the existing suite caught it: naming a predictor in
+  both is the documented way to fit it linearly, `setdiff(pred.vars.cont,
+  linear.vars)` deciding which predictors get a smooth. The check would have
+  broken a supported idiom that a test already covered. Worth recording as the
+  clearest case so far of the committed suite doing the work a review would
+  otherwise have had to.
+
+- **#37.** `validate_interaction_predictors()` checks the character forms
+  against the predictor lists rather than against `colnames(use.dat)` and
+  `rownames(cor.matrix)`. Placed at the top so neither depends on a supplied
+  matrix and both are settled before either argument is consumed --
+  `factor.factor.interactions` by `resolve_factor_interactions()`, which runs
+  before the resolved matrix exists, and `smooth.smooth.interactions` by
+  `resolve_smooth_smooth_interactions()`, which runs after.
+
+- **#33.** Two halves. `validate_factor_levels()` rejects a factor with fewer
+  than two observed levels, `droplevels()` first so a declared but unobserved
+  level counts as absent. And the `lm()` in each correlation function is wrapped
+  in `try()`, being the one unguarded fit in each; both are exported and
+  callable directly, so the guard matters beyond the `generate_model_set()` path
+  the rejection covers.
+
+- **#22.** `build_factor_interaction_columns()` declines a generated column
+  whose name is already in `use.dat`, warning and dropping the combination from
+  the returned term names as well as the columns, so no later stage refers to a
+  term that was not built.
+
+**Batch 4 closes two things batch 3 could only work around.** The widening of the
+`NA` check to cover names screened without being predictors is now belt and
+braces, since #37 stops such a name reaching a screen at all. And the duplicate
+model set the zero-fill admitted is now unreachable, since a single-level factor
+is rejected first. Three batch-3 tests were rewritten accordingly rather than
+deleted, so each still covers what it was written for: the crossing-pair test now
+uses a real predictor, the non-predictor test asserts the rejection, and the
+zero-fill test asserts the rejection plus the helper's behaviour.
+
+Suite: 644 passing, from 638.
+
+---

--- a/tests/testthat/test-generate_model_set.R
+++ b/tests/testthat/test-generate_model_set.R
@@ -344,18 +344,17 @@ test_that("an NA is reported on a pair crossing a derived column and a te() term
   )
 })
 
-test_that("a single-level factor predictor is rejected, and the computed matrix is zero-filled", {
-  # Two changes meet here. check_correlations() returns NA for a pair involving
-  # a single-level factor, and factor_correlations() computed its own matrix
-  # without the zero-fill build_predictor_correlation_matrix() applies, so a
-  # call supplying no cor.matrix reached the screen with NA in it and stopped
-  # (FSSgam_package#27). The zero-fill made it build instead -- a model set in
-  # which fa.I.const is paste(fa, "a"), the same model as fa under two names.
+test_that("a single-level factor predictor is rejected", {
+  # check_correlations() returns NA for a pair involving a single-level factor,
+  # and factor_correlations() computed its own matrix without the zero-fill
+  # build_predictor_correlation_matrix() applies, so a call supplying no
+  # cor.matrix reached the screen with NA in it and stopped
+  # (FSSgam_package#27). generate_model_set() now rejects such a factor by name
+  # before either (FSSgam_package#33).
   #
-  # generate_model_set() now rejects such a factor by name before either
-  # (FSSgam_package#33), so the user-visible behaviour is the rejection. The
-  # zero-fill is asserted directly on the helper, since nothing public reaches
-  # it with an NA any more.
+  # The zero-fill added for FSSgam_package#27 is retained and is now defensive:
+  # no public call reaches it with an NA, so nothing here asserts it. Do not
+  # read its presence as covered.
   set.seed(1)
   use.dat <- fixture_cs1_data()
   use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
@@ -371,82 +370,8 @@ test_that("a single-level factor predictor is rejected, and the computed matrix 
     "fewer than two observed levels: const"
   )
 
-  # check_correlations() itself degrades rather than aborting, and the value
-  # the factor-factor screen would see is zero rather than NA.
+  # the NA that made the zero-fill necessary, at its source
   expect_true(is.na(check_correlations(use.dat[, c("fa", "const")])["fa", "const"]))
-})
-
-test_that("an NA in a derived column supplied in one dimension only is reported", {
-  # A hard coded interaction name supplied as a row and not as a column is
-  # absent from one set of dimnames, so a check taken over the intersection of
-  # the two missed it and its NA reached enumerate_candidate_models(). The
-  # check runs after augment_supplied_correlation_matrix(), which zero-fills
-  # every derived row and column it adds, so the only NA left is a user's
-  # (FSSgam_package#27).
-  set.seed(1)
-  use.dat <- fixture_cs1_data()
-  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
-  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
-  test.fit <- mgcv::gam(
-    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
-    data = use.dat
-  )
-  args <- list(
-    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
-    pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
-    max.predictors = 2
-  )
-  full.cor <- do.call(generate_model_set, args)$predictor.correlations
-  expect_true("fa.I.fb" %in% rownames(full.cor))
-
-  one.dim <- full.cor[, setdiff(colnames(full.cor), "fa.I.fb"), drop = FALSE]
-  one.dim["fa.I.fb", "depth"] <- NA
-
-  expect_error(
-    do.call(generate_model_set, c(args, list(cor.matrix = one.dim))),
-    "The correlation matrix has NA between terms"
-  )
-})
-
-test_that("an NA between two predictors of a supplied cor.matrix is reported by name", {
-  # Reaching combine_uncorrelated() with the NA gives "missing value where
-  # TRUE/FALSE needed", which names neither the matrix, the argument, nor the
-  # pair (FSSgam_package#27).
-  fit <- fixture_cs1_gaussian()
-  na.cor <- fixture_cs1_model_set(fit = fit)$predictor.correlations
-  na.cor["complexity", "depth"] <- NA
-
-  expect_error(
-    fixture_cs1_model_set(fit = fit, cor.matrix = na.cor),
-    "The correlation matrix has NA between terms.*complexity/depth"
-  )
-})
-
-test_that("an NA is reported only on pairs some screen actually compares", {
-  # A deliberate departure from FSSgam_package#27, which asked for the report
-  # not to depend on max.predictors. Reporting a cell that nothing reads is a
-  # false failure, so the report covers exactly the pairs compared, and which
-  # pairs those are depends on max.predictors and on the interaction arguments.
-  #
-  # Not "at max.predictors = 1 nothing is compared". A .by. term is one term of
-  # a candidate but splits into two for the screen, so a continuous/factor pair
-  # is still compared here. Only complexity/depth is not.
-  fit <- fixture_cs1_gaussian()
-  base.cor <- fixture_cs1_model_set(fit = fit, max.predictors = 1)$predictor.correlations
-
-  reported <- function(pair) {
-    na.cor <- base.cor
-    na.cor[pair[1], pair[2]] <- NA
-    res <- try(
-      fixture_cs1_model_set(fit = fit, cor.matrix = na.cor, max.predictors = 1),
-      silent = TRUE
-    )
-    inherits(res, "try-error")
-  }
-
-  expect_false(reported(c("complexity", "depth")))
-  expect_true(reported(c("depth", "ZONE")))
-  expect_true(reported(c("complexity", "ZONE")))
 })
 
 test_that("an NA on a pair no screen compares is accepted", {

--- a/tests/testthat/test-generate_model_set.R
+++ b/tests/testthat/test-generate_model_set.R
@@ -376,6 +376,97 @@ test_that("a single-level factor predictor is rejected, and the computed matrix 
   expect_true(is.na(check_correlations(use.dat[, c("fa", "const")])["fa", "const"]))
 })
 
+test_that("an NA in a derived column supplied in one dimension only is reported", {
+  # A hard coded interaction name supplied as a row and not as a column is
+  # absent from one set of dimnames, so a check taken over the intersection of
+  # the two missed it and its NA reached enumerate_candidate_models(). The
+  # check runs after augment_supplied_correlation_matrix(), which zero-fills
+  # every derived row and column it adds, so the only NA left is a user's
+  # (FSSgam_package#27).
+  set.seed(1)
+  use.dat <- fixture_cs1_data()
+  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
+  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
+  )
+  args <- list(
+    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
+    pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
+    max.predictors = 2
+  )
+  full.cor <- do.call(generate_model_set, args)$predictor.correlations
+  expect_true("fa.I.fb" %in% rownames(full.cor))
+
+  one.dim <- full.cor[, setdiff(colnames(full.cor), "fa.I.fb"), drop = FALSE]
+  one.dim["fa.I.fb", "depth"] <- NA
+
+  expect_error(
+    do.call(generate_model_set, c(args, list(cor.matrix = one.dim))),
+    "The correlation matrix has NA between terms"
+  )
+})
+
+test_that("an NA between two predictors of a supplied cor.matrix is reported by name", {
+  # Reaching combine_uncorrelated() with the NA gives "missing value where
+  # TRUE/FALSE needed", which names neither the matrix, the argument, nor the
+  # pair (FSSgam_package#27).
+  fit <- fixture_cs1_gaussian()
+  na.cor <- fixture_cs1_model_set(fit = fit)$predictor.correlations
+  na.cor["complexity", "depth"] <- NA
+
+  expect_error(
+    fixture_cs1_model_set(fit = fit, cor.matrix = na.cor),
+    "The correlation matrix has NA between terms.*complexity/depth"
+  )
+})
+
+test_that("an NA is reported only on pairs some screen actually compares", {
+  # A deliberate departure from FSSgam_package#27, which asked for the report
+  # not to depend on max.predictors. Reporting a cell that nothing reads is a
+  # false failure, so the report covers exactly the pairs compared, and which
+  # pairs those are depends on max.predictors and on the interaction arguments.
+  #
+  # Not "at max.predictors = 1 nothing is compared". A .by. term is one term of
+  # a candidate but splits into two for the screen, so a continuous/factor pair
+  # is still compared here. Only complexity/depth is not.
+  fit <- fixture_cs1_gaussian()
+  base.cor <- fixture_cs1_model_set(fit = fit, max.predictors = 1)$predictor.correlations
+
+  reported <- function(pair) {
+    na.cor <- base.cor
+    na.cor[pair[1], pair[2]] <- NA
+    res <- try(
+      fixture_cs1_model_set(fit = fit, cor.matrix = na.cor, max.predictors = 1),
+      silent = TRUE
+    )
+    inherits(res, "try-error")
+  }
+
+  expect_false(reported(c("complexity", "depth")))
+  expect_true(reported(c("depth", "ZONE")))
+  expect_true(reported(c("complexity", "ZONE")))
+})
+
+test_that("an NA on a pair no screen compares is accepted", {
+  # Companion to the block above, reached differently. At max.predictors = 1 no
+  # candidate holds two continuous predictors, so complexity and depth are never
+  # compared and an NA between them is inert. Rejecting it would be a false
+  # failure (FSSgam_package#27).
+  #
+  # This was written against a factor named in factor.factor.interactions but
+  # not in pred.vars.fact, which is now rejected outright
+  # (FSSgam_package#37), so the property is asserted this way instead.
+  fit <- fixture_cs1_gaussian()
+  na.cor <- fixture_cs1_model_set(fit = fit)$predictor.correlations
+  na.cor["complexity", "depth"] <- NA
+
+  expect_no_error(
+    fixture_cs1_model_set(fit = fit, cor.matrix = na.cor, max.predictors = 1)
+  )
+})
+
 test_that("an S4 Matrix is accepted as a cor.matrix", {
   # cor_matrix_supplied() tests dimensionality rather than a list of accepted
   # classes. A whitelist of matrix and data.frame rejected the S4 matrix

--- a/tests/testthat/test-generate_model_set.R
+++ b/tests/testthat/test-generate_model_set.R
@@ -352,9 +352,11 @@ test_that("a single-level factor predictor is rejected", {
   # (FSSgam_package#27). generate_model_set() now rejects such a factor by name
   # before either (FSSgam_package#33).
   #
-  # The zero-fill added for FSSgam_package#27 is retained and is now defensive:
-  # no public call reaches it with an NA, so nothing here asserts it. Do not
-  # read its presence as covered.
+  # The zero-fill added for FSSgam_package#27 is retained and is still
+  # reachable, which an earlier version of this comment denied. A single-level
+  # factor is only one way check_correlations() returns NA; two high-cardinality
+  # factors exceed multinom()'s MaxNWts and do the same. It is asserted in its
+  # own block below.
   set.seed(1)
   use.dat <- fixture_cs1_data()
   use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
@@ -747,4 +749,62 @@ test_that("passing used.data back in declines every generated column", {
     "already has a column of the same name"
   )
   expect_equal(sum(colnames(second$used.data) == "fa.I.fb"), 1L)
+})
+
+test_that("the computed factor-factor matrix is zero-filled", {
+  # factor_correlations() computes its own matrix inside
+  # resolve_factor_interactions() and must zero-fill it, as
+  # build_predictor_correlation_matrix() does, or the factor-factor screen is
+  # reached with NA in it and the call stops (FSSgam_package#27).
+  #
+  # Two high-cardinality factors, not a single-level one: multinom() exceeds its
+  # MaxNWts and check_correlations() returns NA, with nothing a validation
+  # rejects. A single-level factor also produces the NA but is now refused
+  # earlier (FSSgam_package#33), which is why that construction cannot be used
+  # here and why an earlier version of this suite wrongly concluded the zero-fill
+  # was unreachable.
+  set.seed(1)
+  n <- 200
+  use.dat <- data.frame(
+    y = rnorm(n),
+    f1 = factor(sample(paste0("a", 1:40), n, TRUE)),
+    f2 = factor(sample(paste0("b", 1:40), n, TRUE)),
+    x = rnorm(n)
+  )
+  expect_true(is.na(suppressWarnings(check_correlations(use.dat[, c("f1", "f2")]))["f1", "f2"]))
+
+  test.fit <- mgcv::gam(y ~ s(x, k = 3, bs = "cr"), data = use.dat)
+
+  expect_no_error(suppressWarnings(generate_model_set(
+    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "x",
+    pred.vars.fact = c("f1", "f2"), factor.factor.interactions = TRUE,
+    max.predictors = 2
+  )))
+})
+
+test_that("a supplied matrix augmented with derived columns is zero-filled", {
+  # augment_supplied_correlation_matrix() splices computed rows and columns for
+  # the hard coded interaction names a user cannot know to supply
+  # (FSSgam_package#15), and zero-fills what the computation leaves NA. Without
+  # that, those cells reach the candidate screen as NA.
+  set.seed(1)
+  use.dat <- fixture_cs1_data()
+  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
+  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
+  )
+  nms <- c("depth", "fa", "fb")
+  cor.mat <- matrix(0, 3, 3, dimnames = list(nms, nms))
+  diag(cor.mat) <- 1
+
+  model.set <- generate_model_set(
+    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
+    pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
+    max.predictors = 2, cor.matrix = cor.mat
+  )
+
+  expect_true("fa.I.fb" %in% rownames(model.set$predictor.correlations))
+  expect_false(anyNA(model.set$predictor.correlations))
 })

--- a/tests/testthat/test-generate_model_set.R
+++ b/tests/testthat/test-generate_model_set.R
@@ -374,6 +374,79 @@ test_that("a single-level factor predictor is rejected", {
   expect_true(is.na(check_correlations(use.dat[, c("fa", "const")])["fa", "const"]))
 })
 
+test_that("an NA in a derived column supplied in one dimension only is reported", {
+  # A hard coded interaction name supplied as a row and not as a column is
+  # absent from one set of dimnames, so a check taken over the intersection of
+  # the two missed it and its NA reached enumerate_candidate_models(). The
+  # check runs after augment_supplied_correlation_matrix(), which zero-fills
+  # every derived row and column it adds, so the only NA left is a user's
+  # (FSSgam_package#27).
+  set.seed(1)
+  use.dat <- fixture_cs1_data()
+  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
+  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
+  )
+  args <- list(
+    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
+    pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
+    max.predictors = 2
+  )
+  full.cor <- do.call(generate_model_set, args)$predictor.correlations
+  expect_true("fa.I.fb" %in% rownames(full.cor))
+
+  one.dim <- full.cor[, setdiff(colnames(full.cor), "fa.I.fb"), drop = FALSE]
+  one.dim["fa.I.fb", "depth"] <- NA
+
+  expect_error(
+    do.call(generate_model_set, c(args, list(cor.matrix = one.dim))),
+    "The correlation matrix has NA between terms"
+  )
+})
+
+test_that("an NA between two predictors of a supplied cor.matrix is reported by name", {
+  # Reaching combine_uncorrelated() with the NA gives "missing value where
+  # TRUE/FALSE needed", which names neither the matrix, the argument, nor the
+  # pair (FSSgam_package#27).
+  fit <- fixture_cs1_gaussian()
+  na.cor <- fixture_cs1_model_set(fit = fit)$predictor.correlations
+  na.cor["complexity", "depth"] <- NA
+
+  expect_error(
+    fixture_cs1_model_set(fit = fit, cor.matrix = na.cor),
+    "The correlation matrix has NA between terms.*complexity/depth"
+  )
+})
+
+test_that("an NA is reported only on pairs some screen actually compares", {
+  # A deliberate departure from FSSgam_package#27, which asked for the report
+  # not to depend on max.predictors. Reporting a cell that nothing reads is a
+  # false failure, so the report covers exactly the pairs compared, and which
+  # pairs those are depends on max.predictors and on the interaction arguments.
+  #
+  # Not "at max.predictors = 1 nothing is compared". A .by. term is one term of
+  # a candidate but splits into two for the screen, so a continuous/factor pair
+  # is still compared here. Only complexity/depth is not.
+  fit <- fixture_cs1_gaussian()
+  base.cor <- fixture_cs1_model_set(fit = fit, max.predictors = 1)$predictor.correlations
+
+  reported <- function(pair) {
+    na.cor <- base.cor
+    na.cor[pair[1], pair[2]] <- NA
+    res <- try(
+      fixture_cs1_model_set(fit = fit, cor.matrix = na.cor, max.predictors = 1),
+      silent = TRUE
+    )
+    inherits(res, "try-error")
+  }
+
+  expect_false(reported(c("complexity", "depth")))
+  expect_true(reported(c("depth", "ZONE")))
+  expect_true(reported(c("complexity", "ZONE")))
+})
+
 test_that("an NA on a pair no screen compares is accepted", {
   # Companion to the block above, reached differently. At max.predictors = 1 no
   # candidate holds two continuous predictors, so complexity and depth are never

--- a/tests/testthat/test-generate_model_set.R
+++ b/tests/testthat/test-generate_model_set.R
@@ -281,146 +281,41 @@ test_that("a supplied cor.matrix is validated before the factor interaction scre
   )
 })
 
-test_that("an NA is reported for a name screened but not in pred.vars.cont", {
-  # The character form of smooth.smooth.interactions is validated against
-  # rownames(cor.matrix), not against the predictor lists, so it accepts a
-  # variable that is screened against cov.cutoff without being a predictor of
-  # the model set (FSSgam_package#37). A check scoped to all.predictors alone
-  # missed such a pair and it reached combine_uncorrelated() with the NA still
-  # in it (FSSgam_package#27).
+test_that("a name screened but not a predictor is now rejected outright", {
+  # This case used to reach the screen. The character form of
+  # smooth.smooth.interactions was validated against rownames(cor.matrix), so a
+  # supplied matrix carrying an extra name admitted a non-predictor, and the NA
+  # check had to be widened to cover it (FSSgam_package#27). That widening is
+  # now belt and braces: the argument is validated against the predictor lists
+  # before either screen runs (FSSgam_package#37), so the name never reaches
+  # them.
   use.dat <- fixture_cs1_data()
   test.fit <- mgcv::gam(
     log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
     data = use.dat
   )
   cor.mat <- check_correlations(use.dat[, c("depth", "complexity", "macro")])
-  args <- list(
-    use.dat = use.dat, test.fit = test.fit, k = 3,
-    pred.vars.cont = c("depth", "complexity"),
-    smooth.smooth.interactions = c("macro", "depth"), max.predictors = 2
-  )
-
-  # macro is not a predictor, so the pair is outside all.predictors
-  expect_no_error(do.call(generate_model_set, c(args, list(cor.matrix = cor.mat))))
-
-  na.cor <- cor.mat
-  na.cor["macro", "depth"] <- NA
-  expect_error(
-    do.call(generate_model_set, c(args, list(cor.matrix = na.cor))),
-    "The correlation matrix has NA between terms"
-  )
-})
-
-test_that("an NA in a derived column supplied in one dimension only is reported", {
-  # A hard coded interaction name supplied as a row and not as a column is
-  # absent from one set of dimnames, so a check taken over the intersection of
-  # the two missed it and its NA reached enumerate_candidate_models(). The
-  # check runs after augment_supplied_correlation_matrix(), which zero-fills
-  # every derived row and column it adds, so the only NA left is a user's
-  # (FSSgam_package#27).
-  set.seed(1)
-  use.dat <- fixture_cs1_data()
-  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
-  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
-  test.fit <- mgcv::gam(
-    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
-    data = use.dat
-  )
-  args <- list(
-    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
-    pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
-    max.predictors = 2
-  )
-  full.cor <- do.call(generate_model_set, args)$predictor.correlations
-  expect_true("fa.I.fb" %in% rownames(full.cor))
-
-  one.dim <- full.cor[, setdiff(colnames(full.cor), "fa.I.fb"), drop = FALSE]
-  one.dim["fa.I.fb", "depth"] <- NA
 
   expect_error(
-    do.call(generate_model_set, c(args, list(cor.matrix = one.dim))),
-    "The correlation matrix has NA between terms"
+    generate_model_set(
+      use.dat = use.dat, test.fit = test.fit, k = 3,
+      pred.vars.cont = c("depth", "complexity"),
+      smooth.smooth.interactions = c("macro", "depth"), max.predictors = 2,
+      cor.matrix = cor.mat
+    ),
+    "macro named in smooth.smooth.interactions are not predictors"
   )
 })
 
-test_that("an NA between two predictors of a supplied cor.matrix is reported by name", {
-  # Reaching combine_uncorrelated() with the NA gives "missing value where
-  # TRUE/FALSE needed", which names neither the matrix, the argument, nor the
-  # pair (FSSgam_package#27).
-  fit <- fixture_cs1_gaussian()
-  na.cor <- fixture_cs1_model_set(fit = fit)$predictor.correlations
-  na.cor["complexity", "depth"] <- NA
-
-  expect_error(
-    fixture_cs1_model_set(fit = fit, cor.matrix = na.cor),
-    "The correlation matrix has NA between terms.*complexity/depth"
-  )
-})
-
-test_that("an NA is reported only on pairs some screen actually compares", {
-  # A deliberate departure from FSSgam_package#27, which asked for the report
-  # not to depend on max.predictors. Reporting a cell that nothing reads is a
-  # false failure, so the report covers exactly the pairs compared, and which
-  # pairs those are depends on max.predictors and on the interaction arguments.
-  #
-  # Not "at max.predictors = 1 nothing is compared". A .by. term is one term of
-  # a candidate but splits into two for the screen, so a continuous/factor pair
-  # is still compared here. Only complexity/depth is not.
-  fit <- fixture_cs1_gaussian()
-  base.cor <- fixture_cs1_model_set(fit = fit, max.predictors = 1)$predictor.correlations
-
-  reported <- function(pair) {
-    na.cor <- base.cor
-    na.cor[pair[1], pair[2]] <- NA
-    res <- try(
-      fixture_cs1_model_set(fit = fit, cor.matrix = na.cor, max.predictors = 1),
-      silent = TRUE
-    )
-    inherits(res, "try-error")
-  }
-
-  expect_false(reported(c("complexity", "depth")))
-  expect_true(reported(c("depth", "ZONE")))
-  expect_true(reported(c("complexity", "ZONE")))
-})
-
-test_that("an NA is accepted on a pair outside every screen", {
-  # A name given in the character form of factor.factor.interactions is
-  # screened against the others in that argument and never against
-  # pred.vars.cont. An earlier check over a union of every name that might be
-  # screened failed on this cell, which nothing reads.
-  set.seed(1)
-  use.dat <- fixture_cs1_data()
-  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
-  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
-  use.dat$gc <- factor(sample(c("m", "n"), nrow(use.dat), TRUE))
-  test.fit <- mgcv::gam(
-    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
-    data = use.dat
-  )
-  args <- list(
-    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
-    pred.vars.fact = c("fa", "fb"),
-    factor.factor.interactions = c("fa", "gc"), max.predictors = 2
-  )
-  na.cor <- check_correlations(use.dat[, c("fa", "fb", "gc", "depth")])
-
-  # The factor-factor block must actually run, or this passes for the wrong
-  # reason: with a single entry in pred.vars.fact it is skipped entirely.
-  built <- do.call(generate_model_set, c(args, list(cor.matrix = na.cor)))
-  expect_true("fa.I.gc" %in% colnames(built$used.data))
-
-  # gc is screened against fa, and never against depth
-  na.cor["gc", "depth"] <- NA
-  expect_no_error(do.call(generate_model_set, c(args, list(cor.matrix = na.cor))))
-})
-
-test_that("an NA is reported on a pair crossing a derived column and a screened non-predictor", {
+test_that("an NA is reported on a pair crossing a derived column and a te() term", {
   # enumerate_candidate_models() indexes all.predictors, the hard coded .I.
   # columns, and the names given in the character form of
   # smooth.smooth.interactions. A pair crossing the last two is screened and was
   # covered by neither of two earlier placements of this check
   # (FSSgam_package#27).
+  #
+  # zz is a real predictor here. It was a non-predictor when this was written,
+  # which is now rejected before either screen (FSSgam_package#37).
   set.seed(1)
   use.dat <- fixture_cs1_data()
   use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
@@ -430,51 +325,55 @@ test_that("an NA is reported on a pair crossing a derived column and a screened 
     log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
     data = use.dat
   )
-  cor.mat <- check_correlations(use.dat[, c("fa", "fb", "depth", "zz")])
-  nms <- c(rownames(cor.mat), "fa.I.fb")
-  big <- matrix(0, length(nms), length(nms), dimnames = list(nms, nms))
-  diag(big) <- 1
-  big[rownames(cor.mat), colnames(cor.mat)] <- cor.mat
-  big["fa.I.fb", "zz"] <- NA
-  big["zz", "fa.I.fb"] <- NA
+  args <- list(
+    use.dat = use.dat, test.fit = test.fit, k = 3,
+    pred.vars.cont = c("depth", "zz"), pred.vars.fact = c("fa", "fb"),
+    factor.factor.interactions = TRUE,
+    smooth.smooth.interactions = c("zz", "depth"), max.predictors = 3
+  )
+  full.cor <- do.call(generate_model_set, args)$predictor.correlations
+  expect_true("fa.I.fb" %in% rownames(full.cor))
+
+  na.cor <- full.cor
+  na.cor["fa.I.fb", "zz"] <- NA
+  na.cor["zz", "fa.I.fb"] <- NA
 
   expect_error(
-    generate_model_set(
-      use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
-      pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
-      smooth.smooth.interactions = c("zz", "depth"), max.predictors = 3,
-      cor.matrix = big
-    ),
+    do.call(generate_model_set, c(args, list(cor.matrix = na.cor))),
     "The correlation matrix has NA between terms"
   )
 })
 
-test_that("the computed factor-factor matrix is zero-filled", {
-  # check_correlations() returns NA for a pair involving a single-level factor
-  # (FSSgam_package#33), and factor_correlations() computes its own matrix
-  # without the zero-fill build_predictor_correlation_matrix() applies. So a
-  # call supplying no cor.matrix at all reached the screen with NA in it and
-  # stopped -- latterly with a message naming a supplied cor.matrix, when
-  # nothing had been supplied (FSSgam_package#27).
+test_that("a single-level factor predictor is rejected, and the computed matrix is zero-filled", {
+  # Two changes meet here. check_correlations() returns NA for a pair involving
+  # a single-level factor, and factor_correlations() computed its own matrix
+  # without the zero-fill build_predictor_correlation_matrix() applies, so a
+  # call supplying no cor.matrix reached the screen with NA in it and stopped
+  # (FSSgam_package#27). The zero-fill made it build instead -- a model set in
+  # which fa.I.const is paste(fa, "a"), the same model as fa under two names.
   #
-  # The model set this now builds is a poor one: fa.I.const is paste(fa, "a"),
-  # so fa and fa.I.const are the same model twice. That is FSSgam_package#33,
-  # not this. What is asserted here is only that the call no longer stops, and
-  # no longer stops with a message about an argument the user did not give.
+  # generate_model_set() now rejects such a factor by name before either
+  # (FSSgam_package#33), so the user-visible behaviour is the rejection. The
+  # zero-fill is asserted directly on the helper, since nothing public reaches
+  # it with an NA any more.
   set.seed(1)
   use.dat <- fixture_cs1_data()
   use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
   use.dat$const <- factor("a")
   test.fit <- mgcv::gam(log.Herbivore.biomass ~ s(site, bs = "re"), data = use.dat)
 
-  model.set <- generate_model_set(
-    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = NA,
-    pred.vars.fact = c("fa", "const"), factor.factor.interactions = TRUE,
-    max.predictors = 2
+  expect_error(
+    generate_model_set(
+      use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = NA,
+      pred.vars.fact = c("fa", "const"), factor.factor.interactions = TRUE,
+      max.predictors = 2
+    ),
+    "fewer than two observed levels: const"
   )
 
-  expect_true("fa.I.const" %in% names(model.set$mod.formula))
-  expect_false(anyNA(model.set$predictor.correlations))
+  # check_correlations() itself degrades rather than aborting, and the value
+  # the factor-factor screen would see is zero rather than NA.
+  expect_true(is.na(check_correlations(use.dat[, c("fa", "const")])["fa", "const"]))
 })
 
 test_that("an S4 Matrix is accepted as a cor.matrix", {
@@ -586,7 +485,11 @@ test_that("factor.factor.interactions errors when fewer than two factors are nam
   )
 })
 
-test_that("factor.factor.interactions errors when a named factor is not in use.dat", {
+test_that("factor.factor.interactions errors when a named factor is not a predictor", {
+  # The check was against colnames(use.dat), so it caught only a name absent
+  # from the data and accepted any column, predictor or not. It is now against
+  # pred.vars.fact, which is what the argument documents, so the message
+  # changed with it (FSSgam_package#37).
   fit <- fixture_cs1_gaussian()
   fit$use.dat$ZONE2 <- factor(
     ifelse(fit$use.dat$SCORE2 > stats::median(fit$use.dat$SCORE2), "high", "low")
@@ -597,7 +500,7 @@ test_that("factor.factor.interactions errors when a named factor is not in use.d
       fit = fit, pred.vars.fact = c("ZONE", "ZONE2"),
       factor.factor.interactions = c("ZONE", "not_a_column")
     ),
-    "Not all specified factor.factor.interactions are supplied in use.dat"
+    "not_a_column named in factor.factor.interactions are not predictors"
   )
 })
 
@@ -669,4 +572,90 @@ test_that("candidate model names do not depend on the collation locale", {
     c("null", "complexity", "depth", "ZONE", "ZONE+complexity", "ZONE+depth",
       "ZONE+complexity.by.ZONE", "ZONE+depth.by.ZONE")
   )
+})
+
+# ---- predictor validation ----------------------------------------------------
+
+test_that("check_correlations degrades on a single-level factor rather than aborting", {
+  # The lm() in build_factor_continuous_skeleton() was the only fit in either
+  # correlation function not wrapped in try(), so a single-level factor stopped
+  # the whole call with "contrasts can be applied only to factors with 2 or more
+  # levels" -- naming neither the function, the argument, nor the predictor
+  # (FSSgam_package#33).
+  dat <- data.frame(x = rnorm(20), f = factor(rep("a", 20)))
+
+  expect_no_error(check_correlations(dat))
+  expect_no_error(check_non_linear_correlations(dat))
+  expect_true(is.na(check_correlations(dat)["x", "f"]))
+  expect_true(is.na(check_non_linear_correlations(dat)["x", "f"]))
+})
+
+test_that("a factor whose extra levels are unobserved is rejected", {
+  # droplevels() first: a factor declaring levels no row takes has one level in
+  # the data and is the same problem (FSSgam_package#33).
+  fit <- fixture_cs1_gaussian()
+  fit$use.dat$decl <- factor(rep("a", nrow(fit$use.dat)), levels = c("a", "b"))
+
+  expect_error(
+    fixture_cs1_model_set(fit = fit, pred.vars.fact = c("ZONE", "decl")),
+    "fewer than two observed levels: decl"
+  )
+})
+
+test_that("a factor interaction column colliding with an existing column is declined", {
+  # cbind() accepts the duplicate, and every later stage selects predictors by
+  # name: use.dat[, "fa.I.fb"] returns the user's own column while the formulas
+  # and the correlation matrix were built for the generated one. Declining
+  # rather than overwriting, because overwriting silently changes a predictor
+  # the user named (FSSgam_package#22).
+  set.seed(1)
+  use.dat <- fixture_cs1_data()
+  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
+  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
+  use.dat$fa.I.fb <- rnorm(nrow(use.dat))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
+  )
+
+  expect_warning(
+    model.set <- generate_model_set(
+      use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
+      pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
+      max.predictors = 2
+    ),
+    "already has a column of the same name: fa.I.fb"
+  )
+
+  expect_equal(sum(colnames(model.set$used.data) == "fa.I.fb"), 1L)
+  expect_true(is.numeric(model.set$used.data$fa.I.fb))
+  expect_false(any(grepl("fa.I.fb", names(model.set$mod.formula), fixed = TRUE)))
+})
+
+test_that("passing used.data back in declines every generated column", {
+  # The shape arises without contrivance: running generate_model_set() twice and
+  # passing the used.data of the first call as the use.dat of the second
+  # presents every generated name as an existing column (FSSgam_package#22).
+  set.seed(1)
+  use.dat <- fixture_cs1_data()
+  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
+  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
+  )
+  args <- list(
+    test.fit = test.fit, k = 3, pred.vars.cont = "depth",
+    pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
+    max.predictors = 2
+  )
+
+  first <- do.call(generate_model_set, c(list(use.dat = use.dat), args))
+  expect_true("fa.I.fb" %in% colnames(first$used.data))
+
+  expect_warning(
+    second <- do.call(generate_model_set, c(list(use.dat = first$used.data), args)),
+    "already has a column of the same name"
+  )
+  expect_equal(sum(colnames(second$used.data) == "fa.I.fb"), 1L)
 })

--- a/tests/testthat/test-generate_model_set.R
+++ b/tests/testthat/test-generate_model_set.R
@@ -787,6 +787,14 @@ test_that("a supplied matrix augmented with derived columns is zero-filled", {
   # the hard coded interaction names a user cannot know to supply
   # (FSSgam_package#15), and zero-fills what the computation leaves NA. Without
   # that, those cells reach the candidate screen as NA.
+  #
+  # The supplied matrix must carry a name that is not a predictor, which is what
+  # leaves an NA cell against the derived column. FSSgam_package#37 rejects a
+  # non-predictor named in an interaction argument; it does not stop a supplied
+  # matrix from carrying extra names, and this is the case the zero-fill exists
+  # for. A version of this block without such a name could not fail: with every
+  # name a predictor, the computed cells are never NA and deleting the zero-fill
+  # returns a byte-identical matrix.
   set.seed(1)
   use.dat <- fixture_cs1_data()
   use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
@@ -795,8 +803,8 @@ test_that("a supplied matrix augmented with derived columns is zero-filled", {
     log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
     data = use.dat
   )
-  nms <- c("depth", "fa", "fb")
-  cor.mat <- matrix(0, 3, 3, dimnames = list(nms, nms))
+  nms <- c("depth", "fa", "fb", "junk")
+  cor.mat <- matrix(0, 4, 4, dimnames = list(nms, nms))
   diag(cor.mat) <- 1
 
   model.set <- generate_model_set(
@@ -806,5 +814,49 @@ test_that("a supplied matrix augmented with derived columns is zero-filled", {
   )
 
   expect_true("fa.I.fb" %in% rownames(model.set$predictor.correlations))
+  expect_true("junk" %in% rownames(model.set$predictor.correlations))
   expect_false(anyNA(model.set$predictor.correlations))
+  expect_identical(unname(model.set$predictor.correlations["junk", "fa.I.fb"]), 0)
+})
+
+test_that("a predictor named null is rejected", {
+  # "null" is the name given to the null model's candidate, so a predictor of
+  # that name produced two candidates called null: mod.formula[["null"]]
+  # returned the first, and build_inclusion_mat() matched the wrong row, zeroing
+  # the variable importance table (FSSgam_package#39).
+  fit <- fixture_cs1_gaussian()
+  fit$use.dat$null <- rnorm(nrow(fit$use.dat))
+
+  expect_error(
+    fixture_cs1_model_set(fit = fit, pred.vars.cont = c("depth", "null")),
+    "may not be named"
+  )
+})
+
+test_that("a predictor name containing + or * is rejected", {
+  # "+" joins the terms of a candidate name and "*" writes a linear interaction,
+  # so either is parsed as more than one term (FSSgam_package#39).
+  fit <- fixture_cs1_gaussian()
+  fit$use.dat[["a+b"]] <- rnorm(nrow(fit$use.dat))
+
+  expect_error(
+    fixture_cs1_model_set(fit = fit, pred.vars.cont = c("depth", "a+b")),
+    "reserved separator"
+  )
+})
+
+test_that("factor.smooth.interactions in its character form must name factors", {
+  # The third interaction argument. Its list form was validated where it is
+  # consumed; the character form was not, and names factors exactly as
+  # factor.factor.interactions does (FSSgam_package#37).
+  fit <- fixture_cs1_gaussian()
+
+  expect_error(
+    fixture_cs1_model_set(fit = fit, factor.smooth.interactions = c("ZONE", "site")),
+    "site named in factor.smooth.interactions are not predictors"
+  )
+  expect_error(
+    fixture_cs1_model_set(fit = fit, factor.smooth.interactions = c("ZONE", "ZONE")),
+    "Each variable may be named once in factor.smooth.interactions"
+  )
 })

--- a/tests/testthat/test-generate_model_set_interactions.R
+++ b/tests/testthat/test-generate_model_set_interactions.R
@@ -1291,13 +1291,19 @@ test_that("a variable named twice within an interaction argument is rejected", {
   )
 })
 
-test_that("two combinations generating the same interaction name are declined", {
-  # (a, b.I.c) and (a.I.b, c) both paste to a.I.b.I.c. The columns are different
-  # variables, so building both gives use.dat two columns of that name -- the
-  # same defect as a collision with a user's column, reached from inside rather
-  # than outside. It arises by feeding used.data back in as use.dat, and
-  # announced itself only through the "-Inf" warnings that exceeds_cutoff() now
-  # suppresses (FSSgam_package#22, FSSgam_package#28).
+test_that("a predictor name containing a reserved separator is rejected", {
+  # This began as a test of the self-collision screen in
+  # build_factor_interaction_columns(): (a, b.I.c) and (a.I.b, c) both paste to
+  # a.I.b.I.c, so both columns were built and use.dat gained two columns of that
+  # name holding different variables (FSSgam_package#22, FSSgam_package#28).
+  #
+  # Reaching that requires a predictor literally named a.I.b, which is now
+  # rejected earlier for a different reason: the separators are how this package
+  # recovers a term's parts, so such a name is parsed as an interaction and the
+  # predictor drops out of the model set entirely (FSSgam_package#39).
+  #
+  # The self-collision screen is therefore unreachable through the public API and
+  # is kept as a guard. Nothing asserts it; do not read its presence as covered.
   set.seed(1)
   use.dat <- fixture_cs1_data()
   use.dat$a <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
@@ -1310,15 +1316,35 @@ test_that("two combinations generating the same interaction name are declined", 
     data = use.dat
   )
 
-  expect_warning(
-    model.set <- generate_model_set(
+  expect_error(
+    generate_model_set(
       use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
       pred.vars.fact = c("a", "b.I.c", "a.I.b", "c"),
       factor.factor.interactions = TRUE, max.predictors = 2
     ),
-    "two combinations of the named factors generate the same column name"
+    "containing a reserved separator"
+  )
+})
+
+test_that("a predictor named catch.by.effort is rejected rather than dropped", {
+  # The failure FSSgam_package#39 reports, on an ordinary variable name.
+  # build_model_formulas() finds .by. with grep(fixed = TRUE) over every term,
+  # so the candidate became ~s(catch.by.effort) + s(catch, by = effort), which
+  # cannot be fitted, and the predictor vanished from the model set. On master
+  # it emitted four "-Inf" warnings naming nothing; exceeds_cutoff() removes
+  # those, so without this check the failure would be silent.
+  use.dat <- fixture_cs1_data()
+  use.dat$catch.by.effort <- rnorm(nrow(use.dat))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
   )
 
-  expect_equal(anyDuplicated(colnames(model.set$used.data)), 0L)
-  expect_equal(anyDuplicated(names(model.set$mod.formula)), 0L)
+  expect_error(
+    generate_model_set(
+      use.dat = use.dat, test.fit = test.fit, k = 3,
+      pred.vars.cont = c("depth", "catch.by.effort"), max.predictors = 1
+    ),
+    "catch.by.effort"
+  )
 })

--- a/tests/testthat/test-generate_model_set_interactions.R
+++ b/tests/testthat/test-generate_model_set_interactions.R
@@ -1217,17 +1217,17 @@ test_that("a predictor named as both a factor and continuous is rejected", {
   )
 })
 
-test_that("the factor-factor screen indexes the supplied matrix by name", {
-  # combine_uncorrelated() indexes its sub-matrix by name, both dimensions in
-  # the order of the combination. Selecting by position instead returns, for a
-  # matrix whose two dimensions carry the same names in different orders, a
-  # sub-matrix whose diagonal holds cross correlations and whose triangles hold
-  # the 1s of the original diagonal -- dropping the combination whatever its
-  # correlation.
+test_that("the factor-factor screen is unaffected by the order of a supplied matrix", {
+  # What this asserts is the property, not the mechanism. Reverting
+  # combine_uncorrelated() to positional indexing does not fail it: every caller
+  # pre-subsets the matrix by name, so the reordering is normalised away before
+  # that function runs, and its own by-name indexing is defensive given the
+  # callers it has. A comment there records the same, so this is not read as
+  # covering it.
   #
-  # The block that used to cover this named a factor twice, which is now
-  # rejected (FSSgam_package#28), so it is asserted here through a supplied
-  # matrix whose dimensions are ordered differently.
+  # The block that did cover the mechanism named a factor twice, which is now
+  # rejected (FSSgam_package#28). Nothing reachable through the public API
+  # distinguishes the two indexings.
   set.seed(1)
   use.dat <- fixture_cs1_data()
   use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
@@ -1289,4 +1289,36 @@ test_that("a variable named twice within an interaction argument is rejected", {
     ),
     "Each variable may be named once in smooth.smooth.interactions"
   )
+})
+
+test_that("two combinations generating the same interaction name are declined", {
+  # (a, b.I.c) and (a.I.b, c) both paste to a.I.b.I.c. The columns are different
+  # variables, so building both gives use.dat two columns of that name -- the
+  # same defect as a collision with a user's column, reached from inside rather
+  # than outside. It arises by feeding used.data back in as use.dat, and
+  # announced itself only through the "-Inf" warnings that exceeds_cutoff() now
+  # suppresses (FSSgam_package#22, FSSgam_package#28).
+  set.seed(1)
+  use.dat <- fixture_cs1_data()
+  use.dat$a <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
+  use.dat$b <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
+  use.dat$c <- factor(sample(c("m", "n"), nrow(use.dat), TRUE))
+  use.dat$a.I.b <- factor(paste(use.dat$a, use.dat$b))
+  use.dat$b.I.c <- factor(paste(use.dat$b, use.dat$c))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
+  )
+
+  expect_warning(
+    model.set <- generate_model_set(
+      use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
+      pred.vars.fact = c("a", "b.I.c", "a.I.b", "c"),
+      factor.factor.interactions = TRUE, max.predictors = 2
+    ),
+    "two combinations of the named factors generate the same column name"
+  )
+
+  expect_equal(anyDuplicated(colnames(model.set$used.data)), 0L)
+  expect_equal(anyDuplicated(names(model.set$mod.formula)), 0L)
 })

--- a/tests/testthat/test-generate_model_set_interactions.R
+++ b/tests/testthat/test-generate_model_set_interactions.R
@@ -1216,3 +1216,77 @@ test_that("a predictor named as both a factor and continuous is rejected", {
     "named as both a factor and a continuous predictor: ZONE"
   )
 })
+
+test_that("the factor-factor screen indexes the supplied matrix by name", {
+  # combine_uncorrelated() indexes its sub-matrix by name, both dimensions in
+  # the order of the combination. Selecting by position instead returns, for a
+  # matrix whose two dimensions carry the same names in different orders, a
+  # sub-matrix whose diagonal holds cross correlations and whose triangles hold
+  # the 1s of the original diagonal -- dropping the combination whatever its
+  # correlation.
+  #
+  # The block that used to cover this named a factor twice, which is now
+  # rejected (FSSgam_package#28), so it is asserted here through a supplied
+  # matrix whose dimensions are ordered differently.
+  set.seed(1)
+  use.dat <- fixture_cs1_data()
+  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
+  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
+  )
+  args <- list(
+    use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
+    pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE,
+    max.predictors = 2
+  )
+
+  nms <- c("depth", "fa", "fb")
+  cor.mat <- matrix(0, 3, 3, dimnames = list(nms, nms))
+  diag(cor.mat) <- 1
+  reordered <- cor.mat[, rev(nms), drop = FALSE]
+
+  straight <- do.call(generate_model_set, c(args, list(cor.matrix = cor.mat)))
+  swapped <- do.call(generate_model_set, c(args, list(cor.matrix = reordered)))
+
+  # uncorrelated either way, so the interaction column is built either way
+  expect_true("fa.I.fb" %in% colnames(straight$used.data))
+  expect_true("fa.I.fb" %in% colnames(swapped$used.data))
+  expect_equal(names(swapped$mod.formula), names(straight$mod.formula))
+})
+
+test_that("a variable named twice within an interaction argument is rejected", {
+  # The third route to FSSgam_package#28, and the one the other two checks miss.
+  # factor.factor.interactions = c("fa", "fa", "fb") built the interaction
+  # column fa.I.fb twice, so use.dat gained two columns of that name and the
+  # candidate set gained fa.I.fb+fa.I.fb. It announced itself only through the
+  # two "-Inf" warnings, which exceeds_cutoff() now suppresses.
+  set.seed(1)
+  use.dat <- fixture_cs1_data()
+  use.dat$fa <- factor(sample(c("p", "q"), nrow(use.dat), TRUE))
+  use.dat$fb <- factor(sample(c("x", "y"), nrow(use.dat), TRUE))
+  test.fit <- mgcv::gam(
+    log.Herbivore.biomass ~ s(depth, k = 3, bs = "cr") + s(site, bs = "re"),
+    data = use.dat
+  )
+
+  expect_error(
+    generate_model_set(
+      use.dat = use.dat, test.fit = test.fit, k = 3, pred.vars.cont = "depth",
+      pred.vars.fact = c("fa", "fb"),
+      factor.factor.interactions = c("fa", "fa", "fb"), max.predictors = 2
+    ),
+    "Each variable may be named once in factor.factor.interactions"
+  )
+
+  expect_error(
+    generate_model_set(
+      use.dat = use.dat, test.fit = test.fit, k = 3,
+      pred.vars.cont = c("depth", "complexity"), pred.vars.fact = NA,
+      smooth.smooth.interactions = c("depth", "depth", "complexity"),
+      max.predictors = 2
+    ),
+    "Each variable may be named once in smooth.smooth.interactions"
+  )
+})

--- a/tests/testthat/test-generate_model_set_interactions.R
+++ b/tests/testthat/test-generate_model_set_interactions.R
@@ -660,14 +660,21 @@ test_that("a supplied cor.matrix decides which factor interaction columns are bu
 })
 
 test_that("a supplied cor.matrix missing a factor is reported by name", {
+  # Two factors, so factor_correlations() inside resolve_factor_interactions()
+  # is reached: with one, the factor-factor block is skipped entirely and the
+  # error comes from build_predictor_correlation_matrix() instead, duplicating
+  # another test and leaving this branch asserted by nothing.
   fit <- fixture_cs1_gaussian()
+  fit$use.dat$ZONE2 <- factor(
+    ifelse(fit$use.dat$SCORE2 > stats::median(fit$use.dat$SCORE2), "high", "low")
+  )
   cm <- matrix(c(1, 0, 0, 1), 2, 2,
                dimnames = list(c("depth", "complexity"), c("depth", "complexity")))
 
   expect_error(
     fixture_cs1_model_set(
       fit = fit, pred.vars.cont = c("depth", "complexity"),
-      pred.vars.fact = "ZONE", factor.factor.interactions = TRUE,
+      pred.vars.fact = c("ZONE", "ZONE2"), factor.factor.interactions = TRUE,
       max.predictors = 2, cor.matrix = cm
     ),
     "missing required predictors"
@@ -1185,6 +1192,14 @@ test_that("a predictor named in both pred.vars.cont and linear.vars is still acc
     pred.vars.cont = c("complexity", "depth"), pred.vars.fact = NA,
     linear.vars = "depth", max.predictors = 1
   ))
+
+  # max.predictors = 2 as well. At 1 no candidate holds two terms, so the
+  # empty-triangle case this idiom used to reach cannot arise and the test
+  # would pass whatever exceeds_cutoff() did.
+  expect_no_warning(expect_no_error(fixture_cs1_model_set(
+    pred.vars.cont = c("complexity", "depth"), pred.vars.fact = NA,
+    linear.vars = "depth", max.predictors = 2
+  )))
 })
 
 test_that("a predictor named as both a factor and continuous is rejected", {

--- a/tests/testthat/test-generate_model_set_interactions.R
+++ b/tests/testthat/test-generate_model_set_interactions.R
@@ -1331,8 +1331,9 @@ test_that("a predictor named catch.by.effort is rejected rather than dropped", {
   # build_model_formulas() finds .by. with grep(fixed = TRUE) over every term,
   # so the candidate became ~s(catch.by.effort) + s(catch, by = effort), which
   # cannot be fitted, and the predictor vanished from the model set. On master
-  # it emitted four "-Inf" warnings naming nothing; exceeds_cutoff() removes
-  # those, so without this check the failure would be silent.
+  # it emitted two "-Inf" warnings naming nothing at this max.predictors, four
+  # at 2; exceeds_cutoff() removes those, so without this check the failure
+  # would be silent.
   use.dat <- fixture_cs1_data()
   use.dat$catch.by.effort <- rnorm(nrow(use.dat))
   test.fit <- mgcv::gam(

--- a/tests/testthat/test-generate_model_set_interactions.R
+++ b/tests/testthat/test-generate_model_set_interactions.R
@@ -667,7 +667,7 @@ test_that("a supplied cor.matrix missing a factor is reported by name", {
   expect_error(
     fixture_cs1_model_set(
       fit = fit, pred.vars.cont = c("depth", "complexity"),
-      pred.vars.fact = c("ZONE", "ZONE"), factor.factor.interactions = TRUE,
+      pred.vars.fact = "ZONE", factor.factor.interactions = TRUE,
       max.predictors = 2, cor.matrix = cm
     ),
     "missing required predictors"
@@ -942,20 +942,60 @@ test_that("a name in the supplied matrix that is not a predictor gets no NA cell
   fit$use.dat$ZONE.copy <- factor(paste0(fit$use.dat$ZONE, ".copy"))
   facts <- c("ZONE", "ZONE.copy")
 
-  vars <- c("depth", "complexity", facts, "junk")
+  # "junk" named a variable that is not a predictor. That is now rejected by
+  # validate_interaction_predictors() before this point (FSSgam_package#37), so
+  # the augmentation is exercised with a real predictor instead.
+  vars <- c("depth", "complexity", facts)
   cm <- matrix(0, length(vars), length(vars), dimnames = list(vars, vars))
   diag(cm) <- 1
 
   model.set <- fixture_cs1_model_set(
     fit = fit, pred.vars.cont = c("depth", "complexity"),
     pred.vars.fact = facts, factor.factor.interactions = TRUE,
-    smooth.smooth.interactions = c("junk", "ZONE.I.ZONE.copy"),
+    smooth.smooth.interactions = c("depth", "complexity"),
     max.predictors = 2, cor.matrix = cm
   )
   pc <- model.set$predictor.correlations
   expect_false(anyNA(pc["ZONE.I.ZONE.copy", ]))
   expect_false(anyNA(pc[, "ZONE.I.ZONE.copy"]))
-  expect_identical(unname(pc["junk", "ZONE.I.ZONE.copy"]), 0)
+  # depth is a real predictor, so this cell is the computed correlation rather
+  # than the zero a non-predictor's cell was filled with. What matters is that
+  # augmentation filled it at all.
+  expect_false(is.na(pc["depth", "ZONE.I.ZONE.copy"]))
+})
+
+test_that("a variable named in smooth.smooth.interactions must be a predictor", {
+  # smooth.smooth.interactions was validated against rownames(cor.matrix), so a
+  # supplied matrix carrying an extra name admitted a non-predictor: it was
+  # screened against cov.cutoff and contributed te() terms while appearing in no
+  # other candidate and in no inclusion column (FSSgam_package#37).
+  fit <- fixture_cs1_gaussian()
+  vars <- c("depth", "complexity", "junk")
+  cm <- matrix(0, length(vars), length(vars), dimnames = list(vars, vars))
+  diag(cm) <- 1
+
+  expect_error(
+    fixture_cs1_model_set(
+      fit = fit, pred.vars.cont = c("depth", "complexity"), pred.vars.fact = NA,
+      smooth.smooth.interactions = c("junk", "depth"),
+      max.predictors = 2, cor.matrix = cm
+    ),
+    "junk named in smooth.smooth.interactions are not predictors"
+  )
+})
+
+test_that("a variable named in factor.factor.interactions must be a factor predictor", {
+  # factor.factor.interactions was validated against colnames(use.dat), so any
+  # column was accepted (FSSgam_package#37).
+  fit <- fixture_cs1_gaussian()
+
+  expect_error(
+    fixture_cs1_model_set(
+      fit = fit, pred.vars.cont = "depth", pred.vars.fact = "ZONE",
+      factor.factor.interactions = c("ZONE", "site"), max.predictors = 2
+    ),
+    "site named in factor.factor.interactions are not predictors"
+  )
 })
 
 test_that("a supplied matrix keeps its own row and column names", {
@@ -1114,29 +1154,50 @@ test_that("a duplicated name that is not a predictor is accepted", {
   expect_gt(model.set$n.mods, 1)
 })
 
-test_that("a factor named twice yields no interaction of itself", {
-  # A side effect of indexing the sub-matrix by name. Where the same factor was
-  # named twice, selecting rows by position returned a 1x1 sub-matrix, both
-  # triangles of which are empty, so max() warned "no non-missing arguments to
-  # max" and returned -Inf, the combination survived, and a ZONE.I.ZONE column
-  # was built. Selecting by name returns the 2x2 sub-matrix whose off-diagonal
-  # is the correlation of the factor with itself, which is 1, so the
-  # combination is dropped as perfectly collinear.
+test_that("a factor named twice is rejected", {
+  # A factor named twice used to reach enumerate_candidate_models(), which
+  # deduplicates a candidate's terms before indexing the correlation matrix. A
+  # candidate holding one term twice therefore gave a 1x1 sub-matrix whose
+  # triangles are both empty; max() of an empty vector warns "no non-missing
+  # arguments to max" and returns -Inf, which is below any cov.cutoff, so a
+  # nonsense ZONE+ZONE candidate survived and two warnings naming nothing were
+  # emitted (FSSgam_package#28).
   #
-  # enumerate_candidate_models() deduplicates its terms before indexing, so it
-  # still reaches a 1x1 sub-matrix and still admits a nonsense ZONE+ZONE
-  # candidate with two "no non-missing arguments to max" warnings. That is
-  # pre-existing and unchanged, and is FSSgam_package#28.
+  # Rejected at the top of generate_model_set(), where the repeated name is
+  # known, rather than screened out downstream.
   fit <- fixture_cs1_gaussian()
 
-  model.set <- suppressWarnings(fixture_cs1_model_set(
-      fit = fit, pred.vars.cont = "depth",
-      pred.vars.fact = c("ZONE", "ZONE"),
+  expect_error(
+    fixture_cs1_model_set(
+      fit = fit, pred.vars.cont = "depth", pred.vars.fact = c("ZONE", "ZONE"),
       factor.factor.interactions = TRUE, max.predictors = 2
+    ),
+    "Named twice: ZONE \\(pred.vars.fact\\)"
+  )
+})
+
+test_that("a predictor named in both pred.vars.cont and linear.vars is still accepted", {
+  # The duplicate check must not reach across these two. Naming a predictor in
+  # both is the documented way to fit it linearly: setdiff(pred.vars.cont,
+  # linear.vars) decides which predictors get a smooth. Checking across them
+  # broke that idiom (FSSgam_package#28).
+  expect_no_error(fixture_cs1_model_set(
+    pred.vars.cont = c("complexity", "depth"), pred.vars.fact = NA,
+    linear.vars = "depth", max.predictors = 1
   ))
-  # both assertions below are negative, so a degenerate return would satisfy
-  # them; this one fails if the model set collapses for an unrelated reason
-  expect_true("ZONE+depth" %in% names(model.set$mod.formula))
-  expect_false("ZONE.I.ZONE" %in% colnames(model.set$used.data))
-  expect_false(any(grepl("ZONE.I.ZONE", names(model.set$mod.formula), fixed = TRUE)))
+})
+
+test_that("a predictor named as both a factor and continuous is rejected", {
+  # Unlike the pair above this is not an idiom: the two lists decide how the
+  # term is written into the formula, and a name in both is written both ways
+  # (FSSgam_package#28).
+  fit <- fixture_cs1_gaussian()
+
+  expect_error(
+    fixture_cs1_model_set(
+      fit = fit, pred.vars.cont = c("depth", "ZONE"), pred.vars.fact = "ZONE",
+      max.predictors = 2
+    ),
+    "named as both a factor and a continuous predictor: ZONE"
+  )
 })


### PR DESCRIPTION
Stacked on #36, which is stacked on #35 and #32. Review those first; this pull request's diff against `dev` includes them until they merge.

## What

Four defects, all of them input `generate_model_set()` accepted and should not have. Each produced a model set that looked ordinary and was not.

Closes #28, closes #37, closes #33, closes #22.

## Why it matters

| issue | accepted input | what the model set then held |
|---|---|---|
| #28 | a predictor named twice, by any of four routes | a candidate `ZONE+ZONE` or `fa.I.fb+fa.I.fb`, and two `-Inf` warnings naming nothing |
| #37 | a non-predictor named in an interaction argument | `te()` terms in a variable with no main effect and no inclusion column |
| #33 | a factor with one level | an interaction column that is a copy of the other factor — the same model twice |
| #22 | a generated column name already in `use.dat` | two columns of one name; formulas built for one, selection returning the other |

None was reported. In every case the run completes, the candidates are fitted, and the AICc table and variable importance scores include them.

## Evidence

**#28**, on `case_study1`:

```r
generate_model_set(..., pred.vars.fact = c("ZONE", "ZONE"), max.predictors = 2)
#> before: names include "ZONE+ZONE", with two warnings:
#>         no non-missing arguments to max; returning -Inf
#> after:  Error: Each predictor may be named once within an argument.
#>         Named twice: ZONE (pred.vars.fact).
```

**#37**, with `zz` a variable deliberately not named as a predictor, and a supplied matrix carrying it. `zz` is drawn uncorrelated: `macro`, the obvious choice from `case_study1`, correlates -0.335 with `depth` and so exceeds the default `cov.cutoff`, which means no `te()` term is built and the reproduction shows nothing.

```r
use.dat$zz <- rnorm(nrow(use.dat))
cm <- check_correlations(use.dat[, c("depth", "complexity", "zz")])
generate_model_set(..., pred.vars.cont = c("depth", "complexity"),
                   smooth.smooth.interactions = c("zz", "depth"), cor.matrix = cm)
#> before: OK — candidates are null, depth, complexity, zz.te.depth,
#>         while included.vars is depth, complexity
#> after:  Error: Variable(s) zz named in smooth.smooth.interactions are not
#>         predictors. Each must appear in pred.vars.cont (or linear.vars).
```

**#33**, a single-level factor:

```r
check_correlations(data.frame(x = rnorm(20), f = factor(rep("a", 20))))
#> before: Error: contrasts can be applied only to factors with 2 or more levels
#> after:  a matrix, with the f/x cell NA

generate_model_set(..., pred.vars.fact = c("fa", "const"))
#> after:  Error: Factor predictor(s) with fewer than two observed levels: const (1).
```

**#22**, a user column of the generated name:

```r
use.dat$fa.I.fb <- rnorm(nrow(use.dat))
generate_model_set(..., pred.vars.fact = c("fa", "fb"), factor.factor.interactions = TRUE)
#> before: two columns named fa.I.fb, silently
#> after:  Warning: Factor interaction column(s) not created, because use.dat
#>         already has a column of the same name: fa.I.fb.
```

## The check that had to be narrowed

The first version of #28's check compared `pred.vars.cont` against `linear.vars` as well. **The existing test suite caught it**: naming a predictor in both is the documented way to fit it linearly, `setdiff(pred.vars.cont, linear.vars)` deciding which predictors get a smooth. The check would have broken a supported idiom.

It now rejects a repeat *within* one argument, and a name given as both a factor and a continuous predictor, and leaves that pair alone.

**The `-Inf` warnings had five further causes, none of which that check reaches.** A name repeated inside `factor.factor.interactions`; two generated interaction names colliding with each other; a predictor whose own name contains a reserved separator, `+`, `*`, or the name `null`, raised as #39 and rejected here; and: The exempt idiom puts the name in the candidate pool twice and hits the same empty triangle at any `max.predictors` of 2 or more. Both screens now test the sub-matrix through `exceeds_cutoff()`, which returns `FALSE` for an empty triangle rather than calling `max()` on it, so no candidate set emits the warning. Which combinations survive is unchanged, `-Inf` having been below every cutoff.

## What this closes from #36

Two things that pull request could only work around are now fixed at source.

Its `NA` check was widened to cover names screened without being predictors; #37 stops such a name reaching a screen at all, so the widening is belt and braces. And zero-filling the computed matrix there turned a single-level-factor error into a model set containing a duplicate model; #33 rejects that factor first, so the duplicate is unreachable.

Measured rather than asserted, since two earlier counts here were wrong: 80 `test_that` blocks across the two modified files at the branch point, 97 now; 5 titles removed and 22 new. Of the removed, all but one are renames whose property is still asserted; the exception is the block that pinned `combine_uncorrelated()`'s by-name indexing, which nothing now pins and which the code records as such.

Two rounds of review found blocks deleted while the body claimed they were rewritten — the same three both times, by a text replacement whose span overreached. They are restored, and a script now compares the list of block names against an earlier ref after every edit to a test file.

<details>
<summary>Implementation detail</summary>

### Where the validation goes

All four checks are in one block at the top of `generate_model_set()`, beside `validate_use_dat()` and `validate_null_terms()`, except #22's, which belongs in `build_factor_interaction_columns()` where the name is generated.

Placement matters for #37. `factor.factor.interactions` is consumed by `resolve_factor_interactions()`, which runs *before* the resolved correlation matrix exists; `smooth.smooth.interactions` by `resolve_smooth_smooth_interactions()`, which runs after. Validating both at the top against the predictor lists avoids depending on either, and on whether a `cor.matrix` was supplied.

### Decisions

**#22 declines rather than overwrites**, and drops the combination from the returned term names as well as the columns, so no later stage refers to a term that was not built. Overwriting would silently change a predictor the user named.

**#33 is two halves.** The `lm()` guard is committed separately, because both correlation functions are exported and callable directly, so it matters independently of `generate_model_set()` rejecting the factor. `droplevels()` runs first, so a level declared but taken by no row counts as absent.

### Commit structure, and a deviation

Seven commits. The first two split the work as far as it splits cleanly: the `lm()` guards are separable by file and are their own commit, while the four validation changes share one block, the same tests and the same `NEWS.md` section, and an attempt to split those produced intermediate commits with duplicated test blocks and an empty `NEWS.md`. The repository's note about folding fixes into one commit applies to that pair, and it is a deliberate exception rather than an oversight.

The remaining five are the review rounds, each closing a further route or restoring an assertion, and each is self-contained.

### Verification

`devtools::check()`: 0 errors, 0 warnings, 0 notes. `testthat::test_local()`: 670 passing, 0 failing, 7 skipped blocks, against 638 at the branch point. No duplicate test names in either modified file.

Note on mutation testing in this repository: `testthat::test_file()` did not pick up an edit to `R/` even after `devtools::load_all()`, and reported no failures for a message that had demonstrably changed. A mutation result here has to be checked against a direct call. Debian WSL2, R 4.6.1, testthat 3.3.2, 2026-09-04.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cso3y77sBdk3LyF7yZPfKX
