### PR TITLE
Batch 6: neither parallel issue produced a fix, and stall rates do not compare across sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -876,6 +876,24 @@ evidence that it works. Both were concluded during the pre-CRAN refactor
 from one observation each, and both were wrong. Measure a rate across fresh
 processes.
 
+**A rate measured in one session is not comparable with one measured in
+another, and the same host gives different rates on different days.**
+Measured 2026-09-05, the identical script and arms: a baseline rate of 13
+stalls in 30 before a WSL crash, and 6 in 60 after the restart. Nothing
+about the code changed. Only arms alternated trial by trial within one run
+can be compared with each other; a figure quoted from a single block is a
+within-run comparison and not a rate that reproduces. That includes the
+figures in the `NEWS.md` entry for the `gamm4` change.
+
+Both directions this issue listed as uninvestigated have now been measured
+and neither is a fix. Over two blocks of 30 trials per arm, alternating:
+`parallel::makePSOCKcluster(setup_strategy = "sequential")` gave 12 stalls
+in 60 against a baseline 6 in 60, and `clusterEvalQ()` pre-loading gave 6 in
+60. An earlier block had suggested `sequential` helped, at 5 in 30 against
+13 in 30; it did not replicate, and the direction reversed. Do not re-try
+either without new evidence. The `ubuntu-latest` comparison remains the
+measurement that would say whether users are affected at all.
+
 ### Phase 14 — Pre-CRAN refactor: defects, argument validation, interaction
 restructure; release 1.1.0 (PR #17) — Completed
 


### PR DESCRIPTION
Stacked on #40. Review that first; this pull request's diff against `dev` includes the whole stack until they merge.

## What

Batch 6 changes no package code. Both its issues were investigated and neither produced a defect to fix. What it adds is one `CLAUDE.md` entry recording a measurement that qualifies every stall figure this repository has published.

Closes nothing. #30 is recommended for closure on the issue; #14 stays open.

## Why there is no code change

**#30 — the premise is false.** The issue reasons that `stats::update()` evaluates a stored call whose function symbol is `dsm`, unresolvable on a `doSNOW` worker. The stored call does not name `dsm`:

```r
stats::getCall(test.fit)[[1]]
#> gam
```

`dsm::dsm()` builds the fit by calling `mgcv::gam()`, and it is that call the object records. `mgcv` is already in the vector `worker_packages()` returns.

Confirmed directly. With `dsm` 2.3.4 installed and a real `dsm` fit built from the package's own `mexdolphins` data, `fit_model_set(parallel = TRUE)` completes with no failed models, and the `dsm` function is not visible on the worker:

```
.packages = mgcv,MuMIn,FSSgam        dsm symbol visible: FALSE | refit: TRUE
.packages = mgcv,MuMIn,FSSgam,dsm    dsm symbol visible: TRUE  | refit: TRUE
```

A `worker_packages(test.fit)` returning `"dsm"` for a `dsm` fit was written, verified to work, and **reverted**. It fixes nothing, and declaring `dsm` under `Suggests` for it would add a dependency and an `R CMD check` NOTE wherever `dsm` is absent, to guard a failure that does not occur.

**#14 — both untried directions were measured, and neither helps.** Two blocks of 30 trials per arm, alternating trial by trial, one cluster per fresh process:

| arm | block 1 | block 2 | pooled | rate |
|---|---|---|---|---|
| baseline | 3/30 | 3/30 | 6/60 | 0.10 |
| `clusterEvalQ` pre-load | 3/30 | 3/30 | 6/60 | 0.10 |
| `setup_strategy = "sequential"` | 7/30 | 5/30 | 12/60 | 0.20 |

Pre-loading is indistinguishable from baseline (p = 1.00). `sequential` is if anything worse (p = 0.20), and the direction is the opposite of what was expected.

## The finding this pull request records

**A stall rate measured in one session is not comparable with one measured in another.** The identical script and arms gave a baseline of 13 stalls in 30 before a WSL crash, and 6 in 60 after the restart, with no change to the code.

That earlier block suggested `setup_strategy = "sequential"` helped — 5/30 against 13/30, p = 0.047. It did not replicate, and the two blocks above reverse its direction.

This is the third result in #14's history to fail replication, so it is recorded as a constraint rather than an anecdote: only arms alternated within one run are comparable, and a figure quoted from a single block is a within-run comparison rather than a rate that reproduces. **That includes the 44-in-140 and 25-in-140 figures in the `NEWS.md` entry for the `gamm4` change**, which the entry presents as rates.

<details>
<summary>Implementation detail</summary>

### The #14 design

A `foreach()` whose body is `i * 2`, so no FSSgam code executes, with `.packages = c("mgcv", "gamm4")`; 25 s timeout against a successful run of 1–2 s; one cluster per fresh `Rscript`, which is what #14 established matters, six consecutive clusters in one session completing 6/6.

Arms alternate trial by trial rather than running in sequence, because #14 records an earlier measurement whose two arms were run one after the other giving a result an independent replication could not reproduce.

Debian WSL2, R 4.6.1, mgcv 1.9-4, gamm4 0.2-6, 2026-09-05.

### What #14 still leaves open

Unchanged: whether this is specific to WSL2 or to this `gamm4`/`lme4`/`Matrix` build, and the mechanism. The `ubuntu-latest` comparison is the measurement that would say whether users are affected at all, and it is now the only listed direction not tried.

### A separate observation from the #30 work

`MuMIn::AICc` returns `NA` for every candidate of a `quasipoisson()` `dsm` fit, so `mod.data.out$AICc` is entirely `NA` and the set cannot be ranked. That is a quasi-likelihood having no AIC, it affects `parallel = FALSE` identically, and it is not what #30 reports. Recorded on that issue rather than pursued here.

### Verification

No package code changed, so the suite and `devtools::check()` are those of #40: 772 passing, 0 failing, 7 skipped blocks; 0 errors, 0 warnings, 0 notes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EbUxJ6dscdnK6S3zB1yxi
