### PR TITLE
Correct four unsupported claims about the parallel stall measurement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -923,23 +923,47 @@ evidence that it works. Both were concluded during the pre-CRAN refactor
 from one observation each, and both were wrong. Measure a rate across fresh
 processes.
 
-**A rate measured in one session is not comparable with one measured in
-another, and the same host gives different rates on different days.**
-Measured 2026-09-05, the identical script and arms: a baseline rate of 13
-stalls in 30 before a WSL crash, and 6 in 60 after the restart. Nothing
-about the code changed. Only arms alternated trial by trial within one run
-can be compared with each other; a figure quoted from a single block is a
-within-run comparison and not a rate that reproduces. That includes the
-figures in the `NEWS.md` entry for the `gamm4` change.
+**These arms have been measured and the measurements settle nothing. The
+sample sizes used are far too small, which was not noticed until it was
+pointed out.**
 
-Both directions this issue listed as uninvestigated have now been measured
-and neither is a fix. Over two blocks of 30 trials per arm, alternating:
-`parallel::makePSOCKcluster(setup_strategy = "sequential")` gave 12 stalls
-in 60 against a baseline 6 in 60, and `clusterEvalQ()` pre-loading gave 6 in
-60. An earlier block had suggested `sequential` helped, at 5 in 30 against
-13 in 30; it did not replicate, and the direction reversed. Do not re-try
-either without new evidence. The `ubuntu-latest` comparison remains the
-measurement that would say whether users are affected at all.
+`setup_strategy = "sequential"` and `clusterEvalQ()` pre-loading were both
+tried on 2026-09-05, two blocks of 30 trials per arm, alternating trial by
+trial: 12 stalls in 60 for `sequential` against a baseline 6 in 60, and 6
+in 60 for pre-loading. That was reported as "neither is a fix". **It does
+not support that.** Simulated power at 60 per arm to detect a halving of a
+0.10 rate is 0.09, so a direction that halved the stall rate would have
+been missed nine times in ten. An independent replication of the same
+design, 212 trials, put `sequential` at parity and pre-loading at an odds
+ratio of 0.23 (p = 0.10) -- the opposite direction for pre-loading. The
+position is undetermined, not settled.
+
+The same applies to the block before it, which measured 13 in 30 against 5
+in 30 for `sequential` and gave p = 0.047. Power for that comparison is
+0.51, so it was a coin flip whether the effect it "found" would appear at
+all. It did not replicate.
+
+**Do not conclude from a stall measurement without computing the power
+first.** Three of these comparisons have now been reported as findings and
+none had the power to support one.
+
+An earlier version of this entry attributed the failure to replicate to
+comparing across sessions, and told future sessions that only arms
+alternated within one run are comparable. Both blocks were alternated
+within one run, so that explanation is refuted by its own data; the sample
+size is the explanation. It also asserted the `NEWS.md` figures for the
+`gamm4` change are within-run comparisons rather than rates. That criticism
+is withdrawn: that entry alternated in blocks of ten across 140 runs and
+already states its figures are one session's measurement on one host. The
+unqualified "1 stall in 50 runs against 21 in 50" earlier in this section
+is the figure that was not alternated.
+
+**`ubuntu-latest` has already been measured and does not reproduce the
+stall.** That is stated in FSSgam_package#14's own comments of 2026-09-01,
+and `.github/workflows/parallel-tests.yaml` runs the opt-in parallel tests
+there on every pull request. Three documents written on 2026-09-05 called
+it the remaining untried direction, which is what comes of writing about an
+issue without reading its comments.
 
 ### Phase 14 — Pre-CRAN refactor: defects, argument validation, interaction
 restructure; release 1.1.0 (PR #17) — Completed


### PR DESCRIPTION
## What

Corrects four claims about the parallel-stall measurement, all made on 2026-09-05 in PR #43, `CLAUDE.md` and a comment on #14. The measurement was underpowered and its conclusion is not supported by its own data.

No package code is touched. `CLAUDE.md` only.

## Why it matters

`CLAUDE.md` is read by every later session, and as merged it told them three things that are false and one that would waste their time:

| claim as merged | correction |
|---|---|
| neither `setup_strategy = "sequential"` nor `clusterEvalQ` pre-loading is a fix | power at 60 trials per arm to detect a **halving** of a 0.10 rate is **0.09**; the measurement cannot distinguish no effect from an effect it could not see |
| the earlier block failed to replicate because rates are not comparable across sessions | both blocks were alternated within one run, so that is refuted by its own data; power for that comparison was **0.51** |
| the `NEWS.md` `gamm4` figures are within-run comparisons rather than rates | withdrawn — that entry alternated in blocks of ten across 140 runs and already states its figures are one session's measurement on one host |
| `ubuntu-latest` is the remaining untried direction | it was measured on 2026-09-01, #14's own comments record it as not reproducing, and `parallel-tests.yaml` runs there on every pull request |

The last is the one that would have cost a later session most: `CLAUDE.md` directed it to redo an automated measurement that runs on every PR.

## Evidence

Power, simulated over 20,000 draws per cell, Fisher's exact at 0.05:

```
n = 60/arm, 0.10 vs 0.05 (a halving)  : 0.09
n = 60/arm, 0.10 vs 0.00 (removal)    : 0.55
n = 30/arm, 0.43 vs 0.17 (the earlier block) : 0.51
```

An independent replication of the same design over 212 trials put `sequential` at parity (8/41 against 8/41) and pre-loading at an odds ratio of 0.23 (2/70 against 8/71, p = 0.10) — the opposite direction for pre-loading.

`ubuntu-latest`: `gh issue view 14 --comments` states "This does not reproduce on `ubuntu-latest`" under 2026-09-01.

`NEWS.md` lines 377 and 387 state "alternating in blocks of ten so that both saw the same machine load" and "one session's measurement of a rate on one host".

<details>
<summary>Implementation detail</summary>

### What the entry now says

That both arms have been measured and the measurements settle nothing; that the sample sizes were far too small; that power must be computed before a stall comparison is reported as a finding; and that `ubuntu-latest` is already covered. It names the unqualified "1 in 50 against 21 in 50" earlier in the same section as the figure that was not alternated, which the withdrawn criticism had aimed at the wrong entry.

### What would settle it

At a 0.10 baseline, detecting a halving at 80% power needs roughly 400 trials per arm rather than 60. Anything smaller should be reported as an interval rather than a direction.

A different measurement is more promising than another rate comparison. The review that found these errors instrumented the stall stage: all 16 baseline and `sequential` stalls occur before the `%dopar%` dispatch, while both pre-loading stalls occur inside `clusterEvalQ`. If that holds, pre-loading relocates the stall rather than removing it, which is direct evidence for the package-loading mechanism #14 records as undemonstrated. I have not re-run it and it is not claimed here.

### How this was found

An independent review of #43, which had already merged. The errors are all of one kind: a conclusion asserted from a measurement without checking whether the measurement could support it, and an issue written about without reading its comments.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EbUxJ6dscdnK6S3zB1yxi
