### PR TITLE
Write closing keywords in the form GitHub resolves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,18 @@ tools/
   and check whether the body's motivation still holds: `FSSgam_package#25`
   argued from a screen that `FSSgam_package#23` had removed in the meantime.
 
+- **A closing keyword needs `beckyfisher/FSSgam_package#41`, not
+  `FSSgam_package#41`.** GitHub resolves `#41` and `owner/repo#41`; the
+  owner-less short form renders as plain text, so no link is made and the issue
+  stays open when the pull request merges. That short form satisfies the
+  qualification rule below on its own, which is how it came to be used. Pull
+  request #46 wrote `Closes FSSgam_package#41` and pull request #48 named
+  FSSgam_package#42 and #44 in prose; both merged, on 2026-09-06 and
+  2026-09-07, and all three issues stayed open until they were closed by hand
+  on 2026-09-07. Write the full `owner/repo#N` form in a closing keyword, which
+  both qualifies the reference and closes the issue. Elsewhere, where a
+  reference is not meant to close anything, either form qualifies it.
+
 - **Vignettes live in the publication repo, not here.** Do not create a
   `vignettes/` folder in this package repo. Full worked examples and case
   studies are permanently hosted at https://github.com/beckyfisher/FSSgam.


### PR DESCRIPTION
## What

`CLAUDE.md` Section 5 gains one rule: a closing keyword in a pull request body
is written `beckyfisher/FSSgam_package#41`, not `FSSgam_package#41`.

## Why it matters

GitHub resolves `#41` and `owner/repo#41`. The owner-less short form renders as
plain text, so no closing link is made and the issue stays open when the pull
request merges. The short form satisfies this repository's existing
qualification rule on its own, which is why it was used.

Three issues stayed open after their fixes merged. Pull request #46 wrote
`Closes FSSgam_package#41`; pull request #48 named FSSgam_package#42 and #44 in
prose only. Both merged, on 2026-09-06 and 2026-09-07, and all three issues were
closed by hand on 2026-09-07.

The full `owner/repo#N` form satisfies both requirements at once. Elsewhere,
where a reference is not meant to close anything, either form qualifies it.

## Evidence

The state of the three issues after each merge, read from the GitHub API on
2026-09-07: `41`, `42` and `44` all `open`, with no linked pull request, against
merged pull requests `46` (`e853712`) and `48` (`b0e3b90`) whose bodies name
them.

No package content changes, so no prompt log entry (Section 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxmcXkcjqHop6RQUkkjKDo